### PR TITLE
Improve exit code handling as signed 32-bit integer

### DIFF
--- a/loaders/python/loader.py
+++ b/loaders/python/loader.py
@@ -574,7 +574,9 @@ def main():
             code = run_mmap(shellcode)
 
     _log('ok', "Exit code: %d" % code)
-    os._exit(code)
+    return_code = ctypes.c_int32(code).value
+    _log('ok', "Interpreted as signed 32-bit: %d" % return_code)
+    os._exit(return_code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request makes a small but important change to how the exit code is handled in `loaders/python/loader.py`. The code now ensures that the exit code is interpreted as a signed 32-bit integer before exiting the process, and logs this interpreted value.

Process exit handling:

* [`loader.py`](diffhunk://#diff-a481f7fc9c8464e752d1687752cb31dc386b0872c0404f3d4c978e65de63a401L577-R579): The exit code from `run_mmap(shellcode)` is now cast to a signed 32-bit integer using `ctypes.c_int32`, and this value is logged before calling `os._exit`. This ensures consistent and correct interpretation of exit codes, especially for negative values.