### PR TITLE
Add no-syscall support for Windows and update NTDLL wrappers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,11 @@ jobs:
           - { target: windows-x86_64,   artifact: windows-x86_64  }
           - { target: windows-armv7a,   artifact: windows-armv7a   }
           - { target: windows-aarch64,  artifact: windows-aarch64  }
+          # ── Windows (no-syscall: direct ntdll exports, Oz only) ──────────
+          - { target: windows-i386,     artifact: windows-i386-nosyscall,    opts: "Oz", cmake_extra: "-DNO_SYSCALL=ON" }
+          - { target: windows-x86_64,   artifact: windows-x86_64-nosyscall,  opts: "Oz", cmake_extra: "-DNO_SYSCALL=ON" }
+          - { target: windows-armv7a,   artifact: windows-armv7a-nosyscall,  opts: "Oz", cmake_extra: "-DNO_SYSCALL=ON" }
+          - { target: windows-aarch64,  artifact: windows-aarch64-nosyscall, opts: "Oz", cmake_extra: "-DNO_SYSCALL=ON" }
           # ── macOS / iOS ──────────────────────────────────────────────────
           - { target: macos-x86_64,     artifact: macos-x86_64    }
           - { target: macos-aarch64,    artifact: macos-aarch64   }
@@ -99,9 +104,9 @@ jobs:
             preset="test-${{ matrix.target }}-release"
             build_dir="build/release"
             out_dir="release/${opt}"
-            echo "=== Building -${opt} (${preset}) ==="
+            echo "=== Building -${opt} (${preset}) ${{ matrix.cmake_extra }} ==="
             rm -rf build
-            cmake --preset "${preset}" -DOPTIMIZATION_LEVEL=${opt}
+            cmake --preset "${preset}" -DOPTIMIZATION_LEVEL=${opt} ${{ matrix.cmake_extra }}
             cmake --build --preset "${preset}"
             mkdir -p "${out_dir}"
             find "${build_dir}" -type f -not -path "*/cmake/*" -exec cp {} "${out_dir}/" \;
@@ -209,6 +214,24 @@ jobs:
             }
           }
 
+  test-windows-i386-nosyscall:
+    needs: build
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with: { name: build-windows-i386-nosyscall, path: release }
+      - name: Test shellcode (PIC loader, no-syscall)
+        shell: pwsh
+        run: |
+          foreach ($dir in Get-ChildItem -Path release -Directory -ErrorAction SilentlyContinue) {
+            foreach ($bin in Get-ChildItem -Path $dir.FullName -Filter "*.bin") {
+              Write-Host "=== Testing PIC -$($dir.Name) (no-syscall) ==="
+              python loaders/python/loader.py --arch i386 $bin.FullName
+              if ($LASTEXITCODE -ne 0) { exit 1 }
+            }
+          }
+
   test-windows-x86_64:
     needs: build
     runs-on: windows-2022
@@ -227,6 +250,24 @@ jobs:
             }
           }
 
+  test-windows-x86_64-nosyscall:
+    needs: build
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with: { name: build-windows-x86_64-nosyscall, path: release }
+      - name: Test shellcode (PIC loader, no-syscall)
+        shell: pwsh
+        run: |
+          foreach ($dir in Get-ChildItem -Path release -Directory -ErrorAction SilentlyContinue) {
+            foreach ($bin in Get-ChildItem -Path $dir.FullName -Filter "*.bin") {
+              Write-Host "=== Testing PIC -$($dir.Name) (no-syscall) ==="
+              python loaders/python/loader.py --arch x86_64 $bin.FullName
+              if ($LASTEXITCODE -ne 0) { exit 1 }
+            }
+          }
+
   test-windows-aarch64:
     needs: build
     runs-on: windows-11-arm
@@ -240,6 +281,24 @@ jobs:
           foreach ($dir in Get-ChildItem -Path release -Directory -ErrorAction SilentlyContinue) {
             foreach ($bin in Get-ChildItem -Path $dir.FullName -Filter "*.bin") {
               Write-Host "=== Testing PIC -$($dir.Name) ==="
+              python loaders/python/loader.py --arch aarch64 $bin.FullName
+              if ($LASTEXITCODE -ne 0) { exit 1 }
+            }
+          }
+
+  test-windows-aarch64-nosyscall:
+    needs: build
+    runs-on: windows-11-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with: { name: build-windows-aarch64-nosyscall, path: release }
+      - name: Test shellcode (PIC loader, no-syscall)
+        shell: pwsh
+        run: |
+          foreach ($dir in Get-ChildItem -Path release -Directory -ErrorAction SilentlyContinue) {
+            foreach ($bin in Get-ChildItem -Path $dir.FullName -Filter "*.bin") {
+              Write-Host "=== Testing PIC -$($dir.Name) (no-syscall) ==="
               python loaders/python/loader.py --arch aarch64 $bin.FullName
               if ($LASTEXITCODE -ne 0) { exit 1 }
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
           - { platform: windows, arch: x86_64,  ext: exe }
           - { platform: windows, arch: aarch64, ext: exe }
           - { platform: windows, arch: armv7a,  ext: exe }
+          # Windows (no-syscall: direct ntdll exports)
+          - { platform: windows, arch: i386,    ext: exe, variant: nosyscall, cmake_extra: "-DNO_SYSCALL=ON" }
+          - { platform: windows, arch: x86_64,  ext: exe, variant: nosyscall, cmake_extra: "-DNO_SYSCALL=ON" }
+          - { platform: windows, arch: aarch64, ext: exe, variant: nosyscall, cmake_extra: "-DNO_SYSCALL=ON" }
+          - { platform: windows, arch: armv7a,  ext: exe, variant: nosyscall, cmake_extra: "-DNO_SYSCALL=ON" }
           # Linux
           - { platform: linux, arch: i386,    ext: elf }
           - { platform: linux, arch: x86_64,  ext: elf }
@@ -89,13 +94,14 @@ jobs:
         run: |
           BUILD_NUMBER=$(git rev-list --count HEAD)
           COMMIT_HASH=$(git rev-parse --short=8 HEAD)
-          cmake --preset ${{ matrix.platform }}-${{ matrix.arch }}-release -DOPTIMIZATION_LEVEL=Oz -DBUILD_NUMBER=${BUILD_NUMBER} -DCOMMIT_HASH=${COMMIT_HASH}
+          cmake --preset ${{ matrix.platform }}-${{ matrix.arch }}-release -DOPTIMIZATION_LEVEL=Oz -DBUILD_NUMBER=${BUILD_NUMBER} -DCOMMIT_HASH=${COMMIT_HASH} ${{ matrix.cmake_extra }}
           cmake --build --preset ${{ matrix.platform }}-${{ matrix.arch }}-release
 
       - name: Rename artifacts
         run: |
           ext="${{ matrix.ext }}"
-          name="${{ matrix.platform }}-${{ matrix.arch }}"
+          variant="${{ matrix.variant }}"
+          name="${{ matrix.platform }}-${{ matrix.arch }}${variant:+-$variant}"
           mkdir -p artifacts
 
           # Find and rename the main executable
@@ -114,7 +120,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-${{ matrix.platform }}-${{ matrix.arch }}
+          name: release-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.variant && format('-{0}', matrix.variant) || '' }}
           retention-days: 1
           path: artifacts/
 

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -21,6 +21,7 @@ set(BUILD_TYPE "release" CACHE STRING "Build type: debug, release")
 set(OPTIMIZATION_LEVEL "" CACHE STRING "Override optimization level (e.g., O2, Os)")
 option(BUILD_TESTS "Build tests instead of beacon" OFF)
 option(ENABLE_LOGGING "Enable logging macros" ON)
+option(NO_SYSCALL "Use direct ntdll exports instead of indirect syscalls (Windows only)" OFF)
 
 # Normalize inputs
 string(TOLOWER "${ARCHITECTURE}" PIR_ARCH)
@@ -81,6 +82,12 @@ if(PIR_BUILD_TYPE STREQUAL "debug")
 endif()
 if(ENABLE_LOGGING)
     list(APPEND PIR_DEFINES ENABLE_LOGGING)
+endif()
+if(NO_SYSCALL)
+    if(NOT PIR_PLATFORM STREQUAL "windows")
+        message(FATAL_ERROR "[pir] NO_SYSCALL is only meaningful on PLATFORM=windows (got '${PIR_PLATFORM}')")
+    endif()
+    list(APPEND PIR_DEFINES NO_SYSCALL)
 endif()
 
 # Log resolved options at verbose level

--- a/src/platform/kernel/windows/NTDLL_WRAPPERS.md
+++ b/src/platform/kernel/windows/NTDLL_WRAPPERS.md
@@ -46,9 +46,11 @@ Result<NTSTATUS, Error> NTDLL::ZwCreateFile(/* params */)
 ```
 
 **Why two paths?**
-- The indirect syscall path is the primary mechanism on x86_64 and i386
-- The `CALL_FUNCTION` fallback exists for architectures where indirect syscalls are not yet fully implemented (ARM64/ARM32 — marked as TODO)
-- Currently `CALL_FUNCTION` returns `-1` as a placeholder
+- The indirect syscall path is the primary mechanism — it avoids leaving a user-mode RIP inside the agent when the `syscall`/`svc` instruction executes
+- `CALL_FUNCTION` resolves the ntdll export via PEB walking and invokes it through a typed function-pointer cast — the same dispatch ntdll itself would do. Used as:
+  - **Fallback** when SSN resolution fails (e.g. hooked or stripped ntdll)
+  - **Primary** on ARM64/ARM32, where the kernel validates that `SVC` originates inside ntdll's address range
+  - **Primary** on every architecture when the build sets `-DNO_SYSCALL=ON` (see the `NO_SYSCALL` CMake option), which shadows `ResolveSyscall` at the top of [`ntdll.cc`](ntdll.cc) to always return an invalid entry, forcing every wrapper down the `CALL_FUNCTION` branch. LTO drops the unused indirect-dispatch code.
 
 ---
 

--- a/src/platform/kernel/windows/ntdll.cc
+++ b/src/platform/kernel/windows/ntdll.cc
@@ -5,143 +5,95 @@
 #include "platform/kernel/windows/system.h"
 
 #define ResolveNtdllExportAddress(functionName) ResolveExportAddressFromPebModule(Djb2::HashCompileTime(L"ntdll.dll"), Djb2::HashCompileTime(functionName))
-// TODO: Implement CALL_FUNCTION for ARM64/ARMV7A — resolve the ntdll export
-// address via ResolveNtdllExportAddress(functionName) and call it directly,
-// since the kernel validates that SVC originates from within ntdll on ARM.
-#define CALL_FUNCTION(functionName, ...) -1
+
+template <typename... Args>
+[[nodiscard]] static inline Result<NTSTATUS, Error> DispatchNt(UINT64 nameHash, Args... args)
+{
+#ifndef NO_SYSCALL
+	SYSCALL_ENTRY entry = System::ResolveSyscallEntry(nameHash);
+	if (entry.Ssn != SYSCALL_SSN_INVALID)
+	{
+		return result::FromNTSTATUS<NTSTATUS>(System::Call(entry, (USIZE)args...));
+	}
+#endif
+	using Fn = NTSTATUS(STDCALL *)(Args...);
+	auto fn = (Fn)ResolveExportAddressFromPebModule(Djb2::HashCompileTime(L"ntdll.dll"), nameHash);
+	return result::FromNTSTATUS<NTSTATUS>(fn(args...));
+}
+
 Result<NTSTATUS, Error> NTDLL::ZwCreateEvent(PPVOID EventHandle, UINT32 DesiredAccess, POBJECT_ATTRIBUTES ObjectAttributes, EVENT_TYPE EventType, INT8 InitialState)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwCreateEvent");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)EventHandle, (USIZE)DesiredAccess, (USIZE)ObjectAttributes, (USIZE)EventType, (USIZE)InitialState)
-						  : CALL_FUNCTION("ZwCreateEvent", PPVOID EventHandle, UINT32 DesiredAccess, POBJECT_ATTRIBUTES ObjectAttributes, EVENT_TYPE EventType, INT8 InitialState);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwCreateEvent"), EventHandle, DesiredAccess, ObjectAttributes, EventType, InitialState);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwDeviceIoControlFile(PVOID FileHandle, PVOID Event, PIO_APC_ROUTINE ApcRoutine, PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, UINT32 IoControlCode, PVOID InputBuffer, UINT32 InputBufferLength, PVOID OutputBuffer, UINT32 OutputBufferLength)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwDeviceIoControlFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)FileHandle, (USIZE)Event, (USIZE)ApcRoutine, (USIZE)ApcContext, (USIZE)IoStatusBlock, (USIZE)IoControlCode, (USIZE)InputBuffer, (USIZE)InputBufferLength, (USIZE)OutputBuffer, (USIZE)OutputBufferLength)
-						  : CALL_FUNCTION("ZwDeviceIoControlFile", PVOID FileHandle, PVOID Event, PIO_APC_ROUTINE ApcRoutine, PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, UINT32 IoControlCode, PVOID InputBuffer, UINT32 InputBufferLength, PVOID OutputBuffer, UINT32 OutputBufferLength);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwDeviceIoControlFile"), FileHandle, Event, ApcRoutine, ApcContext, IoStatusBlock, IoControlCode, InputBuffer, InputBufferLength, OutputBuffer, OutputBufferLength);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwWaitForSingleObject(PVOID Object, INT8 Alertable, PLARGE_INTEGER Timeout)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwWaitForSingleObject");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)Object, (USIZE)Alertable, (USIZE)Timeout)
-						  : CALL_FUNCTION("ZwWaitForSingleObject", PVOID Object, INT8 Alertable, PLARGE_INTEGER Timeout);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwWaitForSingleObject"), Object, Alertable, Timeout);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwClose(PVOID Handle)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwClose");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)Handle)
-						  : CALL_FUNCTION("ZwClose", PVOID Handle);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwClose"), Handle);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwCreateFile(PPVOID FileHandle, UINT32 DesiredAccess, PVOID ObjectAttributes, PIO_STATUS_BLOCK IoStatusBlock, PLARGE_INTEGER AllocationSize, UINT32 FileAttributes, UINT32 ShareAccess, UINT32 CreateDisposition, UINT32 CreateOptions, PVOID EaBuffer, UINT32 EaLength)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwCreateFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)FileHandle, (USIZE)DesiredAccess, (USIZE)ObjectAttributes, (USIZE)IoStatusBlock, (USIZE)AllocationSize, (USIZE)FileAttributes, (USIZE)ShareAccess, (USIZE)CreateDisposition, (USIZE)CreateOptions, (USIZE)EaBuffer, (USIZE)EaLength)
-						  : CALL_FUNCTION("ZwCreateFile", PPVOID FileHandle, UINT32 DesiredAccess, PVOID ObjectAttributes, PIO_STATUS_BLOCK IoStatusBlock, PLARGE_INTEGER AllocationSize, UINT32 FileAttributes, UINT32 ShareAccess, UINT32 CreateDisposition, UINT32 CreateOptions, PVOID EaBuffer, UINT32 EaLength);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwCreateFile"), FileHandle, DesiredAccess, ObjectAttributes, IoStatusBlock, AllocationSize, FileAttributes, ShareAccess, CreateDisposition, CreateOptions, EaBuffer, EaLength);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwAllocateVirtualMemory(PVOID ProcessHandle, PPVOID BaseAddress, USIZE ZeroBits, PUSIZE RegionSize, UINT32 AllocationType, UINT32 Protect)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwAllocateVirtualMemory");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)ProcessHandle, (USIZE)BaseAddress, ZeroBits, (USIZE)RegionSize, (USIZE)AllocationType, (USIZE)Protect)
-						  : CALL_FUNCTION("ZwAllocateVirtualMemory", PVOID ProcessHandle, PPVOID BaseAddress, USIZE ZeroBits, PUSIZE RegionSize, UINT32 AllocationType, UINT32 Protect);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwAllocateVirtualMemory"), ProcessHandle, BaseAddress, ZeroBits, RegionSize, AllocationType, Protect);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwFreeVirtualMemory(PVOID ProcessHandle, PPVOID BaseAddress, PUSIZE RegionSize, UINT32 FreeType)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwFreeVirtualMemory");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)ProcessHandle, (USIZE)BaseAddress, (USIZE)RegionSize, (USIZE)FreeType)
-						  : CALL_FUNCTION("ZwFreeVirtualMemory", PVOID ProcessHandle, PPVOID BaseAddress, PUSIZE RegionSize, UINT32 FreeType);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwFreeVirtualMemory"), ProcessHandle, BaseAddress, RegionSize, FreeType);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwTerminateProcess(PVOID ProcessHandle, NTSTATUS ExitStatus)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwTerminateProcess");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)ProcessHandle, (USIZE)ExitStatus)
-						  : CALL_FUNCTION("ZwTerminateProcess", PVOID ProcessHandle, NTSTATUS ExitStatus);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwTerminateProcess"), ProcessHandle, ExitStatus);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwQueryInformationFile(PVOID FileHandle, PIO_STATUS_BLOCK IoStatusBlock, PVOID FileInformation, UINT32 Length, UINT32 FileInformationClass)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwQueryInformationFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)FileHandle, (USIZE)IoStatusBlock, (USIZE)FileInformation, (USIZE)Length, (USIZE)FileInformationClass)
-						  : CALL_FUNCTION("ZwQueryInformationFile", PVOID FileHandle, PIO_STATUS_BLOCK IoStatusBlock, PVOID FileInformation, UINT32 Length, UINT32 FileInformationClass);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwQueryInformationFile"), FileHandle, IoStatusBlock, FileInformation, Length, FileInformationClass);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwReadFile(PVOID FileHandle, PVOID Event, PIO_APC_ROUTINE ApcRoutine, PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, PVOID Buffer, UINT32 Length, PLARGE_INTEGER ByteOffset, PUINT32 Key)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwReadFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)FileHandle, (USIZE)Event, (USIZE)ApcRoutine, (USIZE)ApcContext, (USIZE)IoStatusBlock, (USIZE)Buffer, (USIZE)Length, (USIZE)ByteOffset, (USIZE)Key)
-						  : CALL_FUNCTION("ZwReadFile", PVOID FileHandle, PVOID Event, PIO_APC_ROUTINE ApcRoutine, PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, PVOID Buffer, UINT32 Length, PLARGE_INTEGER ByteOffset, PUINT32 Key);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwReadFile"), FileHandle, Event, ApcRoutine, ApcContext, IoStatusBlock, Buffer, Length, ByteOffset, Key);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwWriteFile(PVOID FileHandle, PVOID Event, PIO_APC_ROUTINE ApcRoutine, PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, PVOID Buffer, UINT32 Length, PLARGE_INTEGER ByteOffset, PUINT32 Key)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwWriteFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)FileHandle, (USIZE)Event, (USIZE)ApcRoutine, (USIZE)ApcContext, (USIZE)IoStatusBlock, (USIZE)Buffer, (USIZE)Length, (USIZE)ByteOffset, (USIZE)Key)
-						  : CALL_FUNCTION("ZwWriteFile", PVOID FileHandle, PVOID Event, PIO_APC_ROUTINE ApcRoutine, PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, PVOID Buffer, UINT32 Length, PLARGE_INTEGER ByteOffset, PUINT32 Key);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwWriteFile"), FileHandle, Event, ApcRoutine, ApcContext, IoStatusBlock, Buffer, Length, ByteOffset, Key);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwSetInformationFile(PVOID FileHandle, PIO_STATUS_BLOCK IoStatusBlock, PVOID FileInformation, UINT32 Length, UINT32 FileInformationClass)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwSetInformationFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)FileHandle, (USIZE)IoStatusBlock, (USIZE)FileInformation, (USIZE)Length, (USIZE)FileInformationClass)
-						  : CALL_FUNCTION("ZwSetInformationFile", PVOID FileHandle, PIO_STATUS_BLOCK IoStatusBlock, PVOID FileInformation, UINT32 Length, UINT32 FileInformationClass);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwSetInformationFile"), FileHandle, IoStatusBlock, FileInformation, Length, FileInformationClass);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwDeleteFile(POBJECT_ATTRIBUTES FileName)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwDeleteFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)FileName)
-						  : CALL_FUNCTION("ZwDeleteFile", POBJECT_ATTRIBUTES FileName);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwDeleteFile"), FileName);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwQueryAttributesFile(POBJECT_ATTRIBUTES ObjectAttributes, PFILE_BASIC_INFORMATION FileInformation)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwQueryAttributesFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)ObjectAttributes, (USIZE)FileInformation)
-						  : CALL_FUNCTION("ZwQueryAttributesFile", POBJECT_ATTRIBUTES ObjectAttributes, PFILE_BASIC_INFORMATION FileInformation);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwQueryAttributesFile"), ObjectAttributes, FileInformation);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwOpenFile(PPVOID FileHandle, UINT32 DesiredAccess, POBJECT_ATTRIBUTES ObjectAttributes, PIO_STATUS_BLOCK IoStatusBlock, UINT32 ShareAccess, UINT32 OpenOptions)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwOpenFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)FileHandle, (USIZE)DesiredAccess, (USIZE)ObjectAttributes, (USIZE)IoStatusBlock, (USIZE)ShareAccess, (USIZE)OpenOptions)
-						  : CALL_FUNCTION("ZwOpenFile", PPVOID FileHandle, UINT32 DesiredAccess, POBJECT_ATTRIBUTES ObjectAttributes, PIO_STATUS_BLOCK IoStatusBlock, UINT32 ShareAccess, UINT32 OpenOptions);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwOpenFile"), FileHandle, DesiredAccess, ObjectAttributes, IoStatusBlock, ShareAccess, OpenOptions);
 }
 
 Result<VOID, Error> NTDLL::RtlDosPathNameToNtPathName_U(const WCHAR *DosName, UNICODE_STRING *NtName, WCHAR **FilePart, PRTL_RELATIVE_NAME_U RelativeName)
@@ -161,47 +113,27 @@ VOID NTDLL::RtlFreeUnicodeString(PUNICODE_STRING UnicodeString)
 
 Result<NTSTATUS, Error> NTDLL::ZwQueryVolumeInformationFile(PVOID FileHandle, PIO_STATUS_BLOCK IoStatusBlock, PVOID FsInformation, UINT32 Length, UINT32 FsInformationClass)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwQueryVolumeInformationFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)FileHandle, (USIZE)IoStatusBlock, (USIZE)FsInformation, (USIZE)Length, (USIZE)FsInformationClass)
-						  : CALL_FUNCTION("ZwQueryVolumeInformationFile", PVOID FileHandle, PIO_STATUS_BLOCK IoStatusBlock, PVOID FsInformation, UINT32 Length, UINT32 FsInformationClass);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwQueryVolumeInformationFile"), FileHandle, IoStatusBlock, FsInformation, Length, FsInformationClass);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwQueryInformationProcess(PVOID ProcessHandle, UINT32 ProcessInformationClass, PVOID ProcessInformation, UINT32 ProcessInformationLength, PUINT32 ReturnLength)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwQueryInformationProcess");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)ProcessHandle, (USIZE)ProcessInformationClass, (USIZE)ProcessInformation, (USIZE)ProcessInformationLength, (USIZE)ReturnLength)
-						  : CALL_FUNCTION("ZwQueryInformationProcess", PVOID ProcessHandle, UINT32 ProcessInformationClass, PVOID ProcessInformation, UINT32 ProcessInformationLength, PUINT32 ReturnLength);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwQueryInformationProcess"), ProcessHandle, ProcessInformationClass, ProcessInformation, ProcessInformationLength, ReturnLength);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwCreateNamedPipeFile(PPVOID FileHandle, UINT32 DesiredAccess, POBJECT_ATTRIBUTES ObjectAttributes, PIO_STATUS_BLOCK IoStatusBlock, UINT32 ShareAccess, UINT32 CreateDisposition, UINT32 CreateOptions, UINT32 NamedPipeType, UINT32 ReadMode, UINT32 CompletionMode, UINT32 MaximumInstances, UINT32 InboundQuota, UINT32 OutboundQuota, PLARGE_INTEGER DefaultTimeout)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwCreateNamedPipeFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)FileHandle, (USIZE)DesiredAccess, (USIZE)ObjectAttributes, (USIZE)IoStatusBlock, (USIZE)ShareAccess, (USIZE)CreateDisposition, (USIZE)CreateOptions, (USIZE)NamedPipeType, (USIZE)ReadMode, (USIZE)CompletionMode, (USIZE)MaximumInstances, (USIZE)InboundQuota, (USIZE)OutboundQuota, (USIZE)DefaultTimeout)
-						  : CALL_FUNCTION("ZwCreateNamedPipeFile", PPVOID FileHandle, UINT32 DesiredAccess, POBJECT_ATTRIBUTES ObjectAttributes, PIO_STATUS_BLOCK IoStatusBlock, UINT32 ShareAccess, UINT32 CreateDisposition, UINT32 CreateOptions, UINT32 NamedPipeType, UINT32 ReadMode, UINT32 CompletionMode, UINT32 MaximumInstances, UINT32 InboundQuota, UINT32 OutboundQuota, PLARGE_INTEGER DefaultTimeout);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwCreateNamedPipeFile"), FileHandle, DesiredAccess, ObjectAttributes, IoStatusBlock, ShareAccess, CreateDisposition, CreateOptions, NamedPipeType, ReadMode, CompletionMode, MaximumInstances, InboundQuota, OutboundQuota, DefaultTimeout);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwSetInformationObject(PVOID Handle, UINT32 ObjectInformationClass, PVOID ObjectInformation, UINT32 ObjectInformationLength)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwSetInformationObject");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)Handle, (USIZE)ObjectInformationClass, (USIZE)ObjectInformation, (USIZE)ObjectInformationLength)
-						  : CALL_FUNCTION("ZwSetInformationObject", PVOID Handle, UINT32 ObjectInformationClass, PVOID ObjectInformation, UINT32 ObjectInformationLength);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwSetInformationObject"), Handle, ObjectInformationClass, ObjectInformation, ObjectInformationLength);
 }
 
 Result<NTSTATUS, Error> NTDLL::ZwCreateUserProcess(PPVOID ProcessHandle, PPVOID ThreadHandle, UINT32 ProcessDesiredAccess, UINT32 ThreadDesiredAccess, POBJECT_ATTRIBUTES ProcessObjectAttributes, POBJECT_ATTRIBUTES ThreadObjectAttributes, UINT32 ProcessFlags, UINT32 ThreadFlags, PVOID ProcessParameters, PVOID CreateInfo, PVOID AttributeList)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwCreateUserProcess");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)ProcessHandle, (USIZE)ThreadHandle, (USIZE)ProcessDesiredAccess, (USIZE)ThreadDesiredAccess, (USIZE)ProcessObjectAttributes, (USIZE)ThreadObjectAttributes, (USIZE)ProcessFlags, (USIZE)ThreadFlags, (USIZE)ProcessParameters, (USIZE)CreateInfo, (USIZE)AttributeList)
-						  : CALL_FUNCTION("ZwCreateUserProcess", PPVOID ProcessHandle, PPVOID ThreadHandle, UINT32 ProcessDesiredAccess, UINT32 ThreadDesiredAccess, POBJECT_ATTRIBUTES ProcessObjectAttributes, POBJECT_ATTRIBUTES ThreadObjectAttributes, UINT32 ProcessFlags, UINT32 ThreadFlags, PVOID ProcessParameters, PVOID CreateInfo, PVOID AttributeList);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwCreateUserProcess"), ProcessHandle, ThreadHandle, ProcessDesiredAccess, ThreadDesiredAccess, ProcessObjectAttributes, ThreadObjectAttributes, ProcessFlags, ThreadFlags, ProcessParameters, CreateInfo, AttributeList);
 }
 
 Result<NTSTATUS, Error> NTDLL::RtlCreateProcessParametersEx(PVOID *ProcessParameters, PUNICODE_STRING ImagePathName, PUNICODE_STRING DllPath, PUNICODE_STRING CurrentDirectory, PUNICODE_STRING CommandLine, PVOID Environment, PUNICODE_STRING WindowTitle, PUNICODE_STRING DesktopInfo, PUNICODE_STRING ShellInfo, PUNICODE_STRING RuntimeData, UINT32 Flags)
@@ -218,11 +150,7 @@ Result<NTSTATUS, Error> NTDLL::RtlDestroyProcessParameters(PVOID ProcessParamete
 
 Result<NTSTATUS, Error> NTDLL::ZwQueryDirectoryFile(PVOID FileHandle, PVOID Event, PIO_APC_ROUTINE ApcRoutine, PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, PVOID FileInformation, UINT32 Length, UINT32 FileInformationClass, BOOL ReturnSingleEntry, PUNICODE_STRING FileName, BOOL RestartScan)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwQueryDirectoryFile");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)FileHandle, (USIZE)Event, (USIZE)ApcRoutine, (USIZE)ApcContext, (USIZE)IoStatusBlock, (USIZE)FileInformation, (USIZE)Length, (USIZE)FileInformationClass, (USIZE)ReturnSingleEntry, (USIZE)FileName, (USIZE)RestartScan)
-						  : CALL_FUNCTION("ZwQueryDirectoryFile", PVOID FileHandle, PVOID Event, PIO_APC_ROUTINE ApcRoutine, PVOID ApcContext, PIO_STATUS_BLOCK IoStatusBlock, PVOID FileInformation, UINT32 Length, UINT32 FileInformationClass, BOOL ReturnSingleEntry, PUNICODE_STRING FileName, BOOL RestartScan);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwQueryDirectoryFile"), FileHandle, Event, ApcRoutine, ApcContext, IoStatusBlock, FileInformation, Length, FileInformationClass, ReturnSingleEntry, FileName, RestartScan);
 }
 
 Result<NTSTATUS, Error> NTDLL::LdrLoadDll(PWCHAR SearchPath, UINT32 *DllCharacteristics, PUNICODE_STRING DllName, PPVOID BaseAddress)
@@ -233,9 +161,5 @@ Result<NTSTATUS, Error> NTDLL::LdrLoadDll(PWCHAR SearchPath, UINT32 *DllCharacte
 
 Result<NTSTATUS, Error> NTDLL::ZwQuerySystemInformation(UINT32 SystemInformationClass, PVOID SystemInformation, UINT32 SystemInformationLength, PUINT32 ReturnLength)
 {
-	SYSCALL_ENTRY entry = ResolveSyscall("ZwQuerySystemInformation");
-	NTSTATUS status = entry.Ssn != SYSCALL_SSN_INVALID
-						  ? System::Call(entry, (USIZE)SystemInformationClass, (USIZE)SystemInformation, (USIZE)SystemInformationLength, (USIZE)ReturnLength)
-						  : CALL_FUNCTION("ZwQuerySystemInformation", UINT32 SystemInformationClass, PVOID SystemInformation, UINT32 SystemInformationLength, PUINT32 ReturnLength);
-	return result::FromNTSTATUS<NTSTATUS>(status);
+	return DispatchNt(Djb2::HashCompileTime("ZwQuerySystemInformation"), SystemInformationClass, SystemInformation, SystemInformationLength, ReturnLength);
 }


### PR DESCRIPTION
This pull request introduces a new "no-syscall" build and test variant for Windows targets, where system calls are made via direct ntdll exports rather than indirect syscalls. This is implemented through a new `NO_SYSCALL` CMake option, improved dispatch logic in the Windows ntdll wrapper, and expanded CI workflows to build and test these variants. The changes also clarify documentation and refactor the code for maintainability.

**Build system and CI enhancements:**

* Added new Windows build matrix entries in `.github/workflows/build.yml` and `.github/workflows/release.yml` for "no-syscall" variants (`-nosyscall`), using the `NO_SYSCALL` CMake option to force direct ntdll export calls. These variants are built with maximum size optimization (`Oz`). [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R45-R49) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R29-R33)
* Updated the artifact naming and build steps in CI workflows to handle the new variant and ensure the correct CMake options are passed and reflected in artifact names. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L92-R104) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L117-R123) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L102-R109)

**Testing improvements:**

* Added new test jobs for each Windows "no-syscall" variant (i386, x86_64, armv7a, aarch64) in the build workflow, ensuring these builds are tested with the Python loader in CI. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R217-R234) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R253-R270) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R289-R306)

**CMake and configuration:**

* Introduced the `NO_SYSCALL` CMake option in `cmake/Options.cmake`, which is validated to only apply to Windows, and added the appropriate preprocessor define for conditional compilation. [[1]](diffhunk://#diff-232e4d22c3abbcb9e9c9d96fd095c6ba8213536b8d36da499ff28f46b7126ca7R24) [[2]](diffhunk://#diff-232e4d22c3abbcb9e9c9d96fd095c6ba8213536b8d36da499ff28f46b7126ca7R86-R91)

**Windows kernel wrapper refactor:**

* Refactored `src/platform/kernel/windows/ntdll.cc` to centralize syscall/export dispatch logic in a new `DispatchNt` template function, which routes calls through either indirect syscalls or direct ntdll exports depending on the build configuration and runtime conditions. All wrapper functions now use this unified dispatch.
* Updated documentation (`NTDLL_WRAPPERS.md`) to clarify the logic and use cases for the syscall and export paths, including the new `NO_SYSCALL` option and its effects.

These changes make the Windows agent more flexible and robust, allowing builds that never use indirect syscalls (useful for evasion or compatibility), and ensure these variants are continuously built and tested.