### PR TITLE
Fix execution bit determination for non-Windows platforms

### DIFF
--- a/loaders/python/loader.py
+++ b/loaders/python/loader.py
@@ -521,7 +521,7 @@ def main():
     # run_mmap executes shellcode in-process, so it must match the Python
     # interpreter's bitness --not the CPU's.  run_injected (Windows) spawns
     # a native-arch process, so it can use the true OS bitness.
-    exec_bits = python_bits if host_os != 'windows' else host_bits
+    exec_bits = python_bits 
 
     _log('inf', "Host: %s/%s/%dbit" % (host_os, host_family, host_bits))
     _log('inf', "Python: %s (%dbit)" % (platform.python_version(), python_bits))

--- a/loaders/python/loader.py
+++ b/loaders/python/loader.py
@@ -518,9 +518,10 @@ def main():
     host_os, host_family, host_bits = get_host()
     python_bits = struct.calcsize("P") * 8
 
-    # run_mmap executes shellcode in-process, so it must match the Python
-    # interpreter's bitness --not the CPU's.  run_injected (Windows) spawns
-    # a native-arch process, so it can use the true OS bitness.
+    # Execution bitness is always based on the current Python interpreter,
+    # including on Windows. This keeps arch validation and shellcode
+    # selection consistent across both in-process mmap execution and the
+    # Windows injection path, so do not substitute host_bits here.
     exec_bits = python_bits 
 
     _log('inf', "Host: %s/%s/%dbit" % (host_os, host_family, host_bits))

--- a/loaders/python/loader.py
+++ b/loaders/python/loader.py
@@ -522,7 +522,7 @@ def main():
     # including on Windows. This keeps arch validation and shellcode
     # selection consistent across both in-process mmap execution and the
     # Windows injection path, so do not substitute host_bits here.
-    exec_bits = python_bits 
+    exec_bits = python_bits
 
     _log('inf', "Host: %s/%s/%dbit" % (host_os, host_family, host_bits))
     _log('inf', "Python: %s (%dbit)" % (platform.python_version(), python_bits))


### PR DESCRIPTION
This pull request makes a small change to the logic that determines the bitness used for executing shellcode in the `main()` function of `loaders/python/loader.py`. Now, `exec_bits` is always set to the Python interpreter's bitness, regardless of the operating system.