### PR TITLE
Update CONTRIBUTING guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Thank you for your interest in contributing to PIA! This guide covers everything
 | Platform         | Python Version |
 |------------------|----------------|
 | Windows 7        | 3.6            |
-| Windows 8.1 / 10 | 3.13           |
+| Windows 8.1 / 10 | 3.13 +         |
 
 > ⚠️ Due to platform limitations, Windows 7 is restricted to Python 3.6, as newer Python versions no longer support this OS. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,14 @@ Thank you for your interest in contributing to PIA! This guide covers everything
 ## Quick Start
 
 **Requirements:** Clang/LLVM 22+, CMake 3.20+, Ninja 1.10+, C++23. See [Toolchain Installation](#toolchain-installation) below.
+**Python Compatibility:** Python required for running PIA under PIC. The required Python version depends on the operating system:
+
+| Platform         | Python Version |
+|------------------|----------------|
+| Windows 7        | 3.6            |
+| Windows 8.1 / 10 | 3.13           |
+
+> ⚠️ Due to platform limitations, Windows 7 is restricted to Python 3.6, as newer Python versions no longer support this OS. 
 
 > **Windows users:** This project must be built using WSL (Windows Subsystem for Linux). Install WSL, then follow the Linux instructions below to set up the toolchain inside your WSL distribution.
 


### PR DESCRIPTION
This pull request updates the `CONTRIBUTING.md` documentation to clarify Python version compatibility requirements for running PIA under PIC on different Windows platforms. It adds a table specifying the required Python versions for Windows 7 and Windows 8.1/10, and includes a note about platform limitations for Windows 7.
