### PR TITLE
fix(android build): stack-protector + pic-transform shared-LLVM link

### DIFF
--- a/cmake/platforms/Android.cmake
+++ b/cmake/platforms/Android.cmake
@@ -28,6 +28,11 @@ endif()
 # essential since the PIC binary has no dynamic linker to populate them.
 list(APPEND PIR_BASE_FLAGS -fvisibility=hidden)
 
+# Disable stack protector — Clang enables -fstack-protector-strong by default for
+# the android target. The canary (TLS slot) requires CRT-initialized TLS, which is
+# unavailable in this freestanding/-nostdlib binary, leaving __stack_chk_fail undefined.
+list(APPEND PIR_BASE_FLAGS -fno-stack-protector)
+
 # Linker configuration (ELF)
 pir_add_link_flags(
     -e,entry_point

--- a/tools/pic-transform/CMakeLists.txt
+++ b/tools/pic-transform/CMakeLists.txt
@@ -62,7 +62,14 @@ if(NOT LLVM_ENABLE_PLUGINS)
 	if(NOT LLVM_ENABLE_RTTI)
 		target_compile_options(pic-transform PRIVATE -fno-rtti)
 	endif()
-	target_link_libraries(pic-transform PRIVATE ${LLVM_LIBS})
+	# Distros (e.g. Arch) ship component libs as LTO bitcode archives that plain ld
+	# cannot link; prefer the monolithic shared libLLVM-<major>.so in that case.
+	find_library(_PT_LLVM_SHARED NAMES "LLVM-${LLVM_VERSION_MAJOR}" LLVM)
+	if(_PT_LLVM_SHARED)
+		target_link_libraries(pic-transform PRIVATE ${_PT_LLVM_SHARED})
+	else()
+		target_link_libraries(pic-transform PRIVATE ${LLVM_LIBS})
+	endif()
 
 	if(STATIC_LINK)
 		message(STATUS "[pic-transform] Static linking enabled")


### PR DESCRIPTION
## Summary
Two build fixes required to compile the **android** agent (and to build `pic-transform` on shared-LLVM-only distros):

1. **`cmake/platforms/Android.cmake`** — the android clang target enables `-fstack-protector-strong` by default, leaving `__stack_chk_fail` undefined in this freestanding/`-nostdlib` binary (no CRT-initialized TLS). The final link fails with `undefined symbol: __stack_chk_fail`. Add `-fno-stack-protector` (mirrors `FreeBSD.cmake`).
2. **`tools/pic-transform/CMakeLists.txt`** — on distros that ship only the monolithic `libLLVM-<ver>.so` (component `.a` are LTO bitcode plain `ld` can't link, e.g. Arch), `llvm_map_components_to_libnames` yields unusable libs and the `pic-transform` build fails. Prefer `libLLVM-<major>.so` when present, fall back to component libs.

## Validation
Built `android-aarch64-release` end-to-end: `pic-transform` builds, agent links (no `__stack_chk_fail`), PIC verification passes, LOAD segments are 16K-aligned, and the agent executes on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
