### PR TITLE
Sync documentation with API v4 updates and new commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,22 +172,19 @@ For more information, see the [VSCode WSL documentation](https://code.visualstud
 │   ├── entry_point.cc         # Unified platform entry point
 │   ├── core/                  # Layer 1 — types, strings, memory, math (platform-independent)
 │   ├── platform/              # Layer 2 — OS syscalls, file system, sockets, screens (8 platforms)
-│   ├── lib/                   # Layer 3 — crypto, TLS 1.3, HTTP, WebSocket, JPEG
-│   └── beacon/                # Layer 4 — command handlers, shell, screen capture, WebSocket loop
+│   ├── lib/                   # Layer 3 — crypto, TLS 1.3, HTTP, WebSocket, JPEG, shell
+│   └── beacon/                # Layer 4 — command handlers, screen capture, WebSocket loop
 │       ├── main.cc            # WebSocket message loop and command dispatcher
 │       ├── commands.h         # Command types, handler declarations, Context struct
 │       ├── commandsHandler.cc # Command handler implementations
-│       ├── shell.cc/h         # Interactive shell (PTY on POSIX, cmd.exe on Windows)
 │       └── screen_capture.h   # Screen capture context
-├── tests/                     # Test suite (31 test suites across all layers)
+├── tests/                     # Test suite (30 test suites across all layers)
 │   ├── start.cc               # Test harness entry point
 │   └── *_tests.h              # Individual test suites
 ├── tools/
 │   └── pic-transform/         # Custom LLVM pass for PIC enforcement
 └── loaders/
-    ├── python/                # Cross-platform shellcode loader (Python)
-    └── windows/
-        └── powershell/        # Windows shellcode loader (PowerShell)
+    └── python/                # Cross-platform shellcode loader (Python)
 ```
 
 The project is a self-contained monorepo. The `cmake/` directory contains the full build system, and `src/` contains the runtime library and agent code in a layered architecture (core → platform → lib → beacon).
@@ -368,7 +365,7 @@ To add a new command:
 
 ## Testing
 
-The project has 31 test suites covering all layers (core, platform, lib). Tests are built as a separate executable using the same codebase.
+The project has 30 test suites covering all layers (core, platform, lib). Tests are built as a separate executable using the same codebase.
 
 #### Build and run tests
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ This project solves that: a full C++23 codebase that compiles to position-indepe
   - `GetDirectoryContent` - Directory listing with metadata
   - `GetFileContent` - File read at offset
   - `GetFileChunkHash` - SHA-256 hash of file chunk
-  - `WriteShell` / `ReadShell` - Interactive shell (PTY on POSIX, `cmd.exe` on Windows)
+  - `OpenShell` / `CloseShell` - Interactive shell session lifecycle (PTY on POSIX, `cmd.exe` on Windows)
+  - `WriteShell` / `ReadShell` - Shell input/output by server-assigned `shellId`
   - `GetDisplays` - Display enumeration with geometry
   - `GetScreenshot` - JPEG-encoded screenshot capture with dirty-rectangle diffing
-  - `ResetShell` - Resets Shell instance and nullify context
+  - `Exit` - Graceful termination
 
 ### Tested Features
 
@@ -114,7 +115,7 @@ The project is built on a clean layered abstraction that separates concerns and 
 ```
 +-------------------------------------------------------------+
 |  BEACON (Agent Layer)                                       |
-|  Command dispatcher, 9 command handlers, interactive shell   |
+|  Command dispatcher, 11 command handlers, screen capture     |
 +-------------------------------------------------------------+
 |  LIB (Runtime Abstraction Layer)                            |
 |  Cryptography, TLS 1.3, HTTP, DNS, WebSocket, JPEG encoder  |
@@ -133,7 +134,7 @@ The project is built on a clean layered abstraction that separates concerns and 
 
 **LIB** provides high-level libraries: cryptography (SHA-256/384/512, HMAC, ChaCha20-Poly1305, ECC P-256), TLS 1.3, HTTP client, DNS resolution, WebSocket, JPEG encoder, and the interactive shell wrapper.
 
-**BEACON** is the agent layer: command dispatcher, 9 command handlers, and screen capture context. (The interactive shell itself lives in `lib/shell/`; the beacon wires it into the Open/Read/Write/Close shell commands.)
+**BEACON** is the agent layer: command dispatcher, 11 command handlers, and screen capture context. (The interactive shell itself lives in `lib/shell/`; the beacon wires it into the Open/Read/Write/Close shell commands.)
 
 Upper layers depend on lower layers, never the reverse.
 
@@ -142,7 +143,7 @@ src/
 ├── core/        Layer 1 — Primitive types, Result<T,E>, Span<T>, strings, memory ops, math, base64, binary I/O
 ├── platform/    Layer 2 — OS abstraction: syscalls, allocator, console, file system, sockets, screen capture, processes
 ├── lib/         Layer 3 — Crypto (SHA-256, ChaCha20-Poly1305, ECC P-256), TLS 1.3, HTTP, DNS, WebSocket, JPEG encoder, interactive shell
-└── beacon/      Layer 4 — Agent: command dispatcher, 9 command handlers, screen capture context
+└── beacon/      Layer 4 — Agent: command dispatcher, 11 command handlers, screen capture context
 ```
 
 All system interaction is through direct syscalls (NT Native API on Windows, inline assembly on POSIX, Boot Services on UEFI). A custom LLVM pass ([pic-transform](tools/pic-transform/)) eliminates data sections at compile time, ensuring only a `.text` section in the final binary.
@@ -161,13 +162,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full project structure and source
 │   ├── lib/                 # Crypto (SHA-2, ChaCha20, ECC), TLS 1.3, HTTP, DNS, WebSocket, JPEG encoder, interactive shell
 │   ├── beacon/              # Agent: command dispatcher, screen capture
 │   └── entry_point.cc       # Platform entry point
-├── tests/                   # Test suite (31 test suites across all layers)
+├── tests/                   # Test suite (30 test suites across all layers)
 ├── tools/
 │   └── pic-transform/       # Custom LLVM pass for PIC enforcement
 └── loaders/
-    ├── python/              # Cross-platform shellcode loader (Python)
-    └── windows/
-        └── powershell/      # Windows shellcode loader (PowerShell)
+    └── python/              # Cross-platform shellcode loader (Python)
 ```
 
 ---
@@ -191,7 +190,7 @@ OS abstraction layer with [full platform support matrix](src/platform/README.md)
 - **[Memory Allocation](src/platform/memory/README.md)** — The size-header trick (prepending `USIZE` to `mmap` allocations so `munmap` works without caller-supplied size); `mmap2` page-shift on 32-bit Linux; FreeBSD i386 inline assembly hack for 64-bit `off_t` stack parameter
 - **[Screen Capture](src/platform/screen/README.md)** — Linux three-tier fallback chain (X11 protocol → DRM dumb buffers → fbdev); GPU-composited scanout detection via all-black buffer check; macOS `fork()`-based crash isolation for CoreGraphics on headless systems; Retina display scaling; Solaris `/dev/fb` framebuffer
 - **[TCP Sockets](src/platform/socket/README.md)** — Windows AFD driver networking (bypassing Winsock via `\\Device\\Afd\\Endpoint` with IOCTL encoding `(DeviceType << 12) | (FunctionCode << 2) | Method`); Linux i386 `socketcall` multiplexer packing arguments into arrays; UEFI busy-poll pseudo-async with `Stall(1ms)` loops; BSD `sin_len` sockaddr divergence; per-platform `AF_INET6` values (10/23/26/28/30)
-- **[System Utilities](src/platform/system/README.md)** — Five different PTY creation flows across POSIX platforms (Linux `TIOCSPTLCK`/`TIOCGPTN`, macOS `TIOCPTYGRANT`/`TIOCPTYGNAME`, FreeBSD `FIODGNAME`, Solaris STREAMS `I_STR` ioctls with device minor extraction); Windows PEB environment block walking with manual case-insensitive comparison; SMBIOS Type 1 UUID extraction via `NtQuerySystemInformation`
+- **[System Utilities](src/platform/system/README.md)** — Four different PTY creation flows across POSIX platforms (Linux `TIOCSPTLCK`/`TIOCGPTN`, macOS `TIOCPTYGRANT`/`TIOCPTYGNAME`, FreeBSD `FIODGNAME`, Solaris STREAMS `I_STR` ioctls with device minor extraction); Windows PEB environment block walking with manual case-insensitive comparison; SMBIOS Type 1 UUID extraction via `NtQuerySystemInformation`
 
 ### Kernel Interfaces (Layer 2) — [src/platform/kernel/](src/platform/README.md)
 
@@ -224,7 +223,6 @@ The [beacon documentation](src/beacon/README.md) covers the full connection pipe
 
 - **[PIC Transform](tools/pic-transform/README.md)** — Custom LLVM Module pass that converts string literals into stack `alloca` + word-packed immediate stores with register barriers (`asm("": "+r"(val))`) to defeat optimizer re-coalescing; floating-point constants into integer bitcasts; function pointers into PC-relative assembly
 - **[Python Loader](loaders/python/README.md)** — Cross-platform shellcode loader for testing
-- **[PowerShell Loader](loaders/windows/powershell/README.md)** — Windows in-process shellcode loader via function pointer
 
 ---
 
@@ -397,7 +395,7 @@ capability mask so the C2 can determine which feature categories this beacon sup
 |----------------|-------------|--------------------------------------------------|
 | `BuildNumber`  | `UINT32`    | Auto-incrementing build number (git commit count) |
 | `CommitHash`   | `CHAR[9]`   | Short git commit hash (8 hex chars + null)        |
-| `ApiVersion`   | `UINT32`    | Agent API version (starts at 1, bump on breaking protocol change) |
+| `ApiVersion`   | `UINT32`    | Agent API version (currently `4`; bumped on breaking protocol changes) |
 | `Is64Bit`      | `BOOL`      | `true` iff this agent binary is 64-bit (`sizeof(void*) == 8`); agent pointer width, not OS |
 
 `CapabilityMask` layout (packed, 8 bytes = 64 bits, LSB-first per byte):
@@ -492,6 +490,13 @@ Closes a shell session, freeing its slot for reuse. Idempotent — safe to call 
 - **Request**: `UINT64 shellId`
 - **Response**: `UINT32 status`
 
+### `Exit` (0x09)
+
+Gracefully terminates the agent. The handler sets `Context::shouldExit`; the main loop sends the ACK, exits its loops, and tears down through the platform `ExitProcess()` abstraction (on UEFI this maps to `EfiResetShutdown`).
+
+- **Request**: No payload (command type byte only)
+- **Response**: `UINT32 status`
+
 ### `OpenShell` (0x0a)
 
 Opens a new interactive shell session. The beacon owns slot assignment: it picks the first free slot in a 256-slot pool, spawns the shell there, and returns the assigned `shellId`. The client must reuse this id for `WriteShell`/`ReadShell`/`CloseShell` rather than choosing its own. The id is a 64-bit value to match pointer width, leaving room for a future revision to ship an opaque handle instead of a slot index.
@@ -501,7 +506,7 @@ Opens a new interactive shell session. The beacon owns slot assignment: it picks
 
 ## Configuration
 
-- **Server URL**: Defined in `src/beacon/main.cc` (WebSocket endpoint)
+- **Server URL**: Read at startup from the `R_URL` environment variable (`wss://` WebSocket relay endpoint). There is no fallback — the agent exits if `R_URL` is unset.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ Opens a new interactive shell session. The beacon owns slot assignment: it picks
 
 ## Configuration
 
-- **Server URL**: Read at startup from the `R_URL` environment variable (`wss://` WebSocket relay endpoint). There is no fallback — the agent exits if `R_URL` is unset.
+- **Server URL**: Read at startup from the `R_URL` environment variable (accepted schemes: `ws://`, `wss://`, `http://`, `https://`). There is no fallback — the agent exits if `R_URL` is unset.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ The project is built on a clean layered abstraction that separates concerns and 
 ```
 +-------------------------------------------------------------+
 |  BEACON (Agent Layer)                                       |
-|  Command dispatcher, 11 command handlers, screen capture     |
+|  Command dispatcher, 11 command handlers, screen capture    |
 +-------------------------------------------------------------+
 |  LIB (Runtime Abstraction Layer)                            |
 |  Cryptography, TLS 1.3, HTTP, DNS, WebSocket, JPEG encoder  |
 +-------------------------------------------------------------+
 |  PLATFORM (Platform Abstraction Layer)                      |
-|  OS-specific: Windows PEB/NTAPI, Linux/macOS/BSD syscalls    |
+|  OS-specific: Windows PEB/NTAPI, Linux/macOS/BSD syscalls   |
 +-------------------------------------------------------------+
 |  CORE (Core Abstraction Layer)                              |
 |  Platform-independent: Types, Memory, Strings, Algorithms   |

--- a/book-notes/00-INDEX.md
+++ b/book-notes/00-INDEX.md
@@ -22,7 +22,7 @@ The target audience for the book is complete beginners with zero systems program
 | [12-networking.md](12-networking.md) | Network Stack | Questions about DNS, HTTP, TLS, WebSocket |
 | [13-beacon-and-commands.md](13-beacon-and-commands.md) | Beacon Layer | Questions about the command loop, handlers, screen capture |
 | [14-pic-transform.md](14-pic-transform.md) | PIC Transform LLVM Pass | Questions about how string literals become stack immediates |
-| [15-loaders.md](15-loaders.md) | Python and PowerShell Loaders | Questions about how the shellcode gets loaded and executed |
+| [15-loaders.md](15-loaders.md) | Python Loader | Questions about how the shellcode gets loaded and executed |
 | [16-suggested-edits.md](16-suggested-edits.md) | Suggested Edits | Spots where existing docs/comments could be clearer |
 
 ## How to Use These Notes

--- a/book-notes/02-project-overview.md
+++ b/book-notes/02-project-overview.md
@@ -59,7 +59,7 @@ handles all of them.
 ---
 
 ### What is the "relay" mentioned in the architecture?
-**File:** `README.md` **Line(s):** 95-127
+**File:** `docs/02-project-overview.md` **Line(s):** 72-93
 **Type:** QUESTION
 **Priority:** MEDIUM
 
@@ -75,8 +75,8 @@ details are what make it interesting.
 
 ---
 
-### What are the 10 command types?
-**File:** `README.md` **Line(s):** 42-50
+### What are the 11 command types?
+**File:** `README.md` **Line(s):** 51-61
 **Type:** QUESTION
 **Priority:** MEDIUM
 
@@ -85,13 +85,14 @@ The README lists these but doesn't say much about what each one actually does:
 - **Hello** — hostname, OS version, machine ID, etc.
 - **GetDirectoryContent** — lists files and folders (like `ls` or `dir`)
 - **GetFileContent** — downloads a file from the target
+- **GetFileChunkHash** — SHA-256 hash of a file chunk (integrity checking)
 - **WriteShell** — sends keyboard input to an interactive shell
 - **ReadShell** — reads output from that shell
 - **GetDisplays** — enumerates connected monitors
 - **GetScreenshot** — captures what's on screen, with incremental dirty-rect compression
 - **CloseShell** — destroys a shell by id, freeing its slot for reuse
 - **Exit** — gracefully terminate the agent
-- **OpenShell** — opens a new interactive shell session
+- **OpenShell** — opens a new interactive shell session, assigning its id
 
 These are the fundamental operations an operator needs during an engagement.
 Nothing flashy — just solid building blocks.
@@ -118,7 +119,7 @@ precise about it.
 ---
 
 ### What is the "Common Problems and Solutions" section really about?
-**File:** `README.md` **Line(s):** 216-284
+**File:** `README.md` **Line(s):** 229-305
 **Type:** COMMENT
 **Priority:** HIGH
 

--- a/book-notes/13-beacon-and-commands.md
+++ b/book-notes/13-beacon-and-commands.md
@@ -5,35 +5,39 @@ The main agent loop and its command handlers. This is where everything comes tog
 ---
 
 ### How does the main agent loop work?
-**File:** `src/beacon/main.cc` **Line(s):** 31-118
+**File:** `src/beacon/main.cc` **Line(s):** 38-150
 **Type:** QUESTION
 **Priority:** HIGH
 
 The `start()` function is the heart of the agent. The whole flow looks like this:
 ```
 start():
-  1. Build command handler function pointer array (lines 38-46)
-  2. Infinite retry loop:
+  1. Read relay URL from the R_URL environment variable (no fallback)
+  2. Build command handler function pointer array (lines 54-72)
+  3. Infinite retry loop:
      a. Connect: DNS -> TCP -> TLS -> HTTP -> WebSocket
-     b. If connect fails, sleep and retry (line 65-116)
+     b. If connect fails, sleep and retry (lines 91-145)
      c. Message loop:
         - Read a WebSocket message (binary frame)
         - Parse command type from first byte
         - Dispatch to handler[commandType](payload, &response)
         - Send response back over WebSocket
         - If read/write fails, break inner loop and reconnect
-  3. On disconnect, loop back to step 2
+        - If Exit command arrives, ACK then tear down
+  4. On disconnect, loop back to step 3
 ```
-Two things to stress here: the agent never voluntarily exits. It reconnects forever. And each reconnection is completely stateless — no cached sessions, no leftover context. Clean slate every time.
+Two things to stress here: the agent never voluntarily exits on its own — it reconnects forever until an `Exit` command. And each connection attempt is stateless — no cached sessions. Note that `Context` itself is declared before the retry loop, so shell and screen-capture state survives reconnection.
 
 ---
 
 ### What is the function pointer dispatch table?
-**File:** `src/beacon/main.cc` **Line(s):** 38-46
+**File:** `src/beacon/main.cc` **Line(s):** 54-72
 **Type:** QUESTION
 **Priority:** HIGH
 
-An array of function pointers maps command type (integer) to handler function. So `CommandHandler handlers[] = { Handle_Info, Handle_Dir, Handle_File, ... }` means when a command arrives with type=2, the code just calls `handlers[2](payload, &response)`. Faster than a switch/case and trivial to extend — adding a new command means writing a handler function and sticking it in the array at the right index.
+An array of function pointers maps command type (integer) to handler function. So `commandHandlers[Command_GetFileContent] = Handle_GetFileContentCommand` means when a command arrives with type=2, the code just calls `commandHandlers[2](payload, length, &response, &responseLength, &context)`. Faster than a switch/case and trivial to extend — adding a new command means writing a handler function and sticking it in the array at the right index.
+
+Hello and Exit are mandatory core commands, always registered. The other groups (FileSystem, Shell, Display) are guarded by `SUPPORT_<CATEGORY>` macros — compile a category out and its slots stay null, so those command ids answer with `StatusUnknownCommand`.
 
 Worth calling out that virtual methods aren't an option here. Virtual dispatch needs vtables in .rodata, which violates the single-section constraint. Function pointer arrays live on the stack.
 
@@ -60,7 +64,8 @@ Packed structs match the binary protocol exactly, so the receiver can cast raw b
 
 Every handler follows the same pattern — allocate a response buffer and hand ownership to the caller:
 ```
-void Handle_GetInfo(Span<UINT8> payload, PCHAR* response) {
+VOID Handle_HelloCommand(PCHAR command, USIZE commandLength,
+                         PPCHAR response, PUSIZE responseLength, Context *context) {
     // 1. Parse payload (if any)
     // 2. Gather data
     // 3. Allocate response buffer: *response = new CHAR[needed_size]
@@ -68,12 +73,12 @@ void Handle_GetInfo(Span<UINT8> payload, PCHAR* response) {
     // 5. Return (caller responsible for delete[])
 }
 ```
-The double-pointer `PCHAR* response` is an out-parameter: the function writes through the pointer so the caller gets the allocated buffer back. The main loop must `delete[]` the response after sending. No RAII wrappers here — it's all explicit manual management.
+The double-pointer `PPCHAR response` is an out-parameter: the function writes through the pointer so the caller gets the allocated buffer back. The main loop must `delete[]` the response after sending. No RAII wrappers here — it's all explicit manual management.
 
 ---
 
 ### How does the screenshot command work?
-**File:** `src/beacon/commandsHandler.cc` **Line(s):** 385-533
+**File:** `src/beacon/commandsHandler.cc` **Line(s):** 497-646
 **Type:** QUESTION
 **Priority:** HIGH
 
@@ -109,7 +114,7 @@ The first screenshot always sends the entire screen since everything counts as "
 ---
 
 ### What is the JPEG compression threshold and why 24?
-**File:** `src/beacon/commandsHandler.cc` **Line(s):** 457-462
+**File:** `src/beacon/commandsHandler.cc` **Line(s):** 569-574
 **Type:** QUESTION
 **Priority:** LOW
 
@@ -118,24 +123,24 @@ The diff comparison doesn't use exact equality — it uses a threshold of 24. He
 ---
 
 ### How does the shell command work?
-**File:** `src/beacon/shell.h` **Line(s):** 1-40
+**File:** `src/lib/shell/shell.h` **Line(s):** 1-105
 **Type:** QUESTION
 **Priority:** MEDIUM
 
-Shell commands give the operator interactive command-line access. WriteShell sends input to the shell process stdin; ReadShell pulls output from stdout/stderr. Under the hood, the Shell class wraps a ShellProcess from the platform layer — on POSIX that's `/bin/sh` over a PTY, on Windows it's `cmd.exe` with three pipes.
+Shell commands give the operator interactive command-line access. The beacon owns a 256-slot shell pool (`ShellManager`): OpenShell spawns a shell in the first free slot and returns the assigned 64-bit `shellId`; WriteShell/ReadShell/CloseShell all address the session by that id rather than the client choosing one. WriteShell sends input to the shell process stdin; ReadShell pulls merged stdout+stderr. Under the hood, the Shell class wraps a ShellProcess from the platform layer — on POSIX that's `/bin/sh` over a PTY (single stream), on Windows it's `cmd.exe` over two pipes with stderr redirected into the stdout pipe (a separate, never-read stderr pipe would stall cmd.exe).
 
-The read side uses a polling loop: first poll with a 5-second timeout to wait for output to start, then subsequent polls at 100ms to catch rapid bursts. Stops when the timeout expires or the buffer fills. The full path looks like: operator types in web UI -> relay -> agent -> shell process -> output flows back through agent -> relay -> UI.
+The read side uses a polling loop: first poll with a 5-second timeout to wait for output to start, then subsequent polls at 100ms to catch rapid bursts. Stops when the timeout expires, the shell prompt character appears, or the buffer fills. The full path looks like: operator types in web UI -> relay -> agent -> shell process -> output flows back through agent -> relay -> UI.
 
 ---
 
 ### What is the Context struct?
-**File:** `src/beacon/commands.h` **Line(s):** 46-63
+**File:** `src/beacon/commands.h` **Line(s):** 140-157
 **Type:** QUESTION
 **Priority:** MEDIUM
 
-Most commands are stateless (Hello, GetFileContent — run and done). But some need to persist state between calls. The shell process stays open between WriteShell/ReadShell commands. Screenshots need the previous frame for dirty-rect comparison.
+Most commands are stateless (Hello, GetFileContent — run and done). But some need to persist state between calls. The shell pool keeps sessions open between OpenShell/WriteShell/ReadShell commands. Screenshots need the previous frame for dirty-rect comparison.
 
-Context holds pointers to these persistent objects. It gets allocated once and lives for the entire session, then gets reset on reconnection — each new WebSocket connection starts with a fresh Context.
+Context holds a `ShellManager` by value plus the screen-capture pointer. It's declared before the outer reconnect loop, so it lives for the entire agent lifetime — shell sessions and the screenshot diff state survive reconnection. The destructor tears everything down when the agent exits.
 
 ---
 

--- a/book-notes/15-loaders.md
+++ b/book-notes/15-loaders.md
@@ -1,4 +1,4 @@
-# 15 - Loaders (Python and PowerShell)
+# 15 - Loaders (Python)
 
 How shellcode gets loaded into memory and executed. The agent binary is just raw bytes — it needs something to put it in executable memory and jump to it.
 
@@ -11,7 +11,7 @@ How shellcode gets loaded into memory and executed. The agent binary is just raw
 
 The agent compiles to a .bin file — raw machine code, no headers, no metadata. Those bytes can't just run on their own. They need to land in executable memory and get jumped to. That's what a loader does: allocate memory with execute permission, copy the shellcode in, and jump to byte zero (which is the entry point).
 
-The loader itself is a normal program. It doesn't need to be position-independent. Different loaders exist for different scenarios — Python for cross-platform quick testing, PowerShell for Windows enterprise environments, and in real engagements you'd write custom loaders, use process injection, whatever fits the situation.
+The loader itself is a normal program. It doesn't need to be position-independent. The Python loader handles cross-platform quick testing (POSIX in-process, Windows process injection), and in real engagements you'd write custom loaders, use process injection, whatever fits the situation.
 
 ---
 

--- a/docs/02-project-overview.md
+++ b/docs/02-project-overview.md
@@ -17,24 +17,24 @@ This is standard architecture for penetration testing tools. Cobalt Strike has i
 The codebase follows a strict 4-layer design. Each layer depends only on layers below it — never sideways or upward.
 
 ```
-+---------------------------------------------------------------+
++----------------------------------------------------------------+
 |  BEACON (src/beacon/)                          4 files         |
 |  Agent command loop, handlers, screen capture                  |
-+---------------------------------------------------------------+
++----------------------------------------------------------------+
 |  LIB (src/lib/)                               32 files         |
-|  Crypto, TLS 1.3, HTTP, DNS, WebSocket, JPEG, shell, containers |
-+---------------------------------------------------------------+
+|  Crypto, TLS 1.3, HTTP, DNS, WebSocket, JPEG, shell, containers|
++----------------------------------------------------------------+
 |  PLATFORM (src/platform/)                     82 files         |
 |  Console, filesystem, sockets, screen, memory, system utils    |
 |  Implementations in: posix/, windows/, uefi/                   |
-+---------------------------------------------------------------+
++----------------------------------------------------------------+
 |  KERNEL (src/platform/kernel/)                88 files         |
 |  Raw syscall definitions and OS API wrappers                   |
 |  Per-OS: linux/, windows/, macos/, freebsd/, solaris/, uefi/   |
-+---------------------------------------------------------------+
++----------------------------------------------------------------+
 |  CORE (src/core/)                             32 files         |
 |  Types, memory ops, strings, math, algorithms, compiler RT     |
-+---------------------------------------------------------------+
++----------------------------------------------------------------+
 ```
 
 **Core** sits at the bottom. Pure C++ with no knowledge of any operating system. Types (`Result`, `Span`, `Error`), memory operations (`memset`, `memcpy`), strings, math, hashing, Base64, binary I/O. Everything here works identically on every platform.

--- a/docs/02-project-overview.md
+++ b/docs/02-project-overview.md
@@ -18,21 +18,21 @@ The codebase follows a strict 4-layer design. Each layer depends only on layers 
 
 ```
 +---------------------------------------------------------------+
-|  BEACON (src/beacon/)                          6 files         |
-|  Agent command loop, handlers, shell, screen capture           |
+|  BEACON (src/beacon/)                          4 files         |
+|  Agent command loop, handlers, screen capture                  |
 +---------------------------------------------------------------+
-|  LIB (src/lib/)                               30 files         |
-|  Crypto, TLS 1.3, HTTP, DNS, WebSocket, JPEG, containers      |
+|  LIB (src/lib/)                               32 files         |
+|  Crypto, TLS 1.3, HTTP, DNS, WebSocket, JPEG, shell, containers |
 +---------------------------------------------------------------+
-|  PLATFORM (src/platform/)                     81 files         |
+|  PLATFORM (src/platform/)                     82 files         |
 |  Console, filesystem, sockets, screen, memory, system utils    |
 |  Implementations in: posix/, windows/, uefi/                   |
 +---------------------------------------------------------------+
-|  KERNEL (src/platform/kernel/)                81 files         |
+|  KERNEL (src/platform/kernel/)                88 files         |
 |  Raw syscall definitions and OS API wrappers                   |
 |  Per-OS: linux/, windows/, macos/, freebsd/, solaris/, uefi/   |
 +---------------------------------------------------------------+
-|  CORE (src/core/)                             31 files         |
+|  CORE (src/core/)                             32 files         |
 |  Types, memory ops, strings, math, algorithms, compiler RT     |
 +---------------------------------------------------------------+
 ```
@@ -45,7 +45,7 @@ The codebase follows a strict 4-layer design. Each layer depends only on layers 
 
 **Lib** contains higher-level functionality built on Platform. The full crypto suite (ChaCha20-Poly1305, SHA-256/384, ECC), TLS 1.3 client, HTTP/1.1 client, DNS-over-HTTPS resolver, WebSocket client, JPEG encoder, and a dynamic array container. This layer has zero platform-specific code — it uses the Platform API exclusively.
 
-**Beacon** is the top layer. The actual agent logic: connect to the relay via WebSocket, receive commands, dispatch to handlers, send responses, reconnect on failure. Six files total.
+**Beacon** is the top layer. The actual agent logic: connect to the relay via WebSocket, receive commands, dispatch to handlers, send responses, reconnect on failure. Four files total.
 
 Why strict layering? Because you can swap the Platform layer to port to a new OS without touching Lib or Beacon. That's how 8 platforms are supported without 8 copies of the networking code.
 
@@ -94,21 +94,23 @@ See `docs/12-networking.md` for the full breakdown of each layer.
 
 ---
 
-## The 9 Command Types
+## The 11 Command Types
 
-The agent supports 9 commands, dispatched via a function pointer array (see `docs/13-beacon.md`):
+The agent supports 11 commands, dispatched via a function pointer array (see `docs/13-beacon.md`):
 
 | Command | What It Does |
 |---------|-------------|
-| `Hello` | Handshake: collects hostname, username, OS version, machine UUID, CPU architecture + reports a 256-bit capability mask |
+| `Hello` | Handshake: collects hostname, username, OS version, machine UUID, CPU architecture + reports a 64-bit capability mask |
 | `GetDirectoryContent` | Lists files and folders in a directory (like `ls` or `dir`) |
 | `GetFileContent` | Reads a file at a specified offset |
 | `GetFileChunkHash` | SHA-256 hash of a file chunk (for integrity checking) |
-| `WriteShell` | Sends keyboard input to an interactive shell process |
-| `ReadShell` | Reads output from the shell process |
+| `OpenShell` | Opens a new shell session; the beacon assigns and returns the `shellId` |
+| `WriteShell` | Sends keyboard input to an open shell session by `shellId` |
+| `ReadShell` | Reads output from an open shell session by `shellId` |
+| `CloseShell` | Closes a shell session by `shellId`, freeing its slot for reuse |
 | `GetDisplays` | Enumerates connected monitors with geometry info |
 | `GetScreenshot` | Captures the screen as JPEG with incremental dirty-rectangle compression |
-| `ResetShell` | Resets the shell instance, nullifying the pointer and freeing resources. |
+| `Exit` | Gracefully terminates the agent |
 
 These are the fundamental building blocks an operator needs during an engagement. Nothing flashy — just solid primitives that compose well.
 

--- a/docs/04-entry-point.md
+++ b/docs/04-entry-point.md
@@ -246,9 +246,14 @@ somewhere." The linker finds it later. The definition lives in
 ```cpp
 INT32 start()
 {
-    const CHAR url[] = "https://relay.nostdlib.workers.dev/agent";
+    // Resolve the relay URL from the R_URL environment variable at runtime.
+    // There is no fallback: the agent will not run without an explicit endpoint.
+    CHAR urlBuffer[512];
+    USIZE urlLen = Environment::GetVariable("R_URL", Span<CHAR>(urlBuffer, sizeof(urlBuffer)));
+    if (urlLen == 0)
+        return 0;
     // ... registers command handlers ...
-    while (1)
+    while (!context.shouldExit)
     {
         // connect to relay, read commands, dispatch to handlers, reconnect on failure
     }

--- a/docs/13-beacon.md
+++ b/docs/13-beacon.md
@@ -12,7 +12,7 @@ called), [06 - Memory and Strings](06-memory-and-strings.md) (manual allocation)
 typedefs used everywhere).
 
 **Primary source files:**
-- `src/beacon/main.cc` -- the main loop (118 lines)
+- `src/beacon/main.cc` -- the main loop (150 lines)
 - `src/beacon/commands.h` -- `CommandType` enum, `Context` struct, handler typedefs
 - `src/beacon/commandsHandler.cc` -- all command handler implementations
 - `src/lib/shell/shell.h` -- interactive shell wrapper
@@ -26,26 +26,38 @@ Open `src/beacon/main.cc`. The `start()` function is the entire agent. It does
 three things: build the dispatch table, connect, and process commands. Here is the
 full flow, annotated against the source.
 
-**Step 1 -- Build the dispatch table (lines 38-46):**
+**Step 1 -- Build the dispatch table (lines 54-72):**
 
 ```cpp
 CommandHandler commandHandlers[CommandType::CommandTypeCount] = {nullptr};
+// Core (mandatory, always registered)
 commandHandlers[CommandType::Command_Hello] = Handle_HelloCommand;
-commandHandlers[CommandType::Command_GetDirectoryContent] = Handle_GetDirectoryContentCommand;
-commandHandlers[CommandType::Command_GetFileContent] = Handle_GetFileContentCommand;
-commandHandlers[CommandType::Command_GetFileChunkHash] = Handle_GetFileChunkHashCommand;
-commandHandlers[CommandType::Command_WriteShell] = Handle_WriteShellCommand;
-commandHandlers[CommandType::Command_ReadShell] = Handle_ReadShellCommand;
-commandHandlers[CommandType::Command_GetDisplays] = Handle_GetDisplaysCommand;
-commandHandlers[CommandType::Command_GetScreenshot] = Handle_GetScreenshotCommand;
-commandHandlers[CommandType::Command_CloseShell] = Handle_CloseShellCommand;
 commandHandlers[CommandType::Command_Exit] = Handle_ExitCommand;
-commandHandlers[CommandType::Command_OpenShell] = Handle_OpenShellCommand;
+#if SUPPORT_FILESYSTEM
+commandHandlers[CommandType::Command_GetDirectoryContent] = Handle_GetDirectoryContentCommand;
+commandHandlers[CommandType::Command_GetFileContent]      = Handle_GetFileContentCommand;
+commandHandlers[CommandType::Command_GetFileChunkHash]    = Handle_GetFileChunkHashCommand;
+#endif
+#if SUPPORT_SHELL
+commandHandlers[CommandType::Command_OpenShell]  = Handle_OpenShellCommand;
+commandHandlers[CommandType::Command_CloseShell] = Handle_CloseShellCommand;
+commandHandlers[CommandType::Command_ReadShell]  = Handle_ReadShellCommand;
+commandHandlers[CommandType::Command_WriteShell] = Handle_WriteShellCommand;
+#endif
+#if SUPPORT_DISPLAY
+commandHandlers[CommandType::Command_GetDisplays]   = Handle_GetDisplaysCommand;
+commandHandlers[CommandType::Command_GetScreenshot] = Handle_GetScreenshotCommand;
+#endif
 ```
+
+`Hello` and `Exit` are mandatory core commands and are always registered. The
+other three groups are guarded by the `SUPPORT_<CATEGORY>` macros (default `1`);
+when a category is compiled out, its slots stay `nullptr` and the dispatcher
+answers those command ids with `StatusUnknownCommand`.
 
 This array lives on the stack. That matters -- see section 2.
 
-**Step 2 -- Connect (lines 50-62):**
+**Step 2 -- Connect (lines 76-88):**
 
 The outer `while (!context.shouldExit)` loop runs until the operator sends an
 `Exit` command (otherwise it reconnects forever). Each iteration attempts a WebSocket
@@ -61,7 +73,7 @@ logs the failure and loops back. There is no backoff in the current code -- it
 retries immediately. Each connection attempt is completely stateless. No cached
 sessions, no leftover context from the previous attempt.
 
-**Step 3 -- Message loop (lines 65-113):**
+**Step 3 -- Message loop (lines 91-145):**
 
 The inner `while (!context.shouldExit)` reads binary WebSocket frames. Each frame
 is a command (it also exits when an `Exit` command sets the flag, after sending
@@ -110,7 +122,7 @@ in `.rodata` breaks position independence.
 A function pointer array allocated on the stack avoids this entirely. The
 pointers themselves resolve to PC-relative addresses at link time (the PIC
 transform handles this -- see [14 - PIC Transform](14-pic-transform.md)). The
-array is just eight stack slots. No data sections needed.
+array is just eleven stack slots. No data sections needed.
 
 A `switch/case` would also work, but the array approach is both faster (O(1)
 index vs. a jump table the compiler may or may not generate) and easier to

--- a/docs/14-pic-transform.md
+++ b/docs/14-pic-transform.md
@@ -212,39 +212,6 @@ CreateRemoteThread(process.handle, remote_addr)
 
 The suspended `cmd.exe` never actually runs — it's a container for the shellcode. The shellcode ends up running under `cmd.exe`'s identity in the process list, not the Python loader's. The loader can exit after injection and the shellcode keeps going.
 
-### PowerShell Loader
-
-PowerShell can't call Win32 APIs natively, so it uses P/Invoke through inline C# (`Add-Type`):
-
-```powershell
-Add-Type -TypeDefinition @'
-public static class Win32 {
-    [DllImport("kernel32.dll")]
-    public static extern IntPtr VirtualAlloc(IntPtr addr, UIntPtr size, uint type, uint protect);
-    [DllImport("kernel32.dll")]
-    public static extern bool VirtualProtect(IntPtr addr, UIntPtr size, uint prot, out uint old);
-}
-'@
-
-# Allocate RW
-$addr = [Win32]::VirtualAlloc([IntPtr]::Zero, [UIntPtr]::new($len), 0x3000, 0x04)
-
-# Copy shellcode
-[System.Runtime.InteropServices.Marshal]::Copy($shellcode, 0, $addr, $len)
-
-# Flip to RX
-[Win32]::VirtualProtect($addr, [UIntPtr]::new($len), 0x20, [ref]$old)
-
-# Execute via delegate
-$func = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer(
-    $addr, [type][PayloadEntry])
-$func.Invoke()
-```
-
-Same W^X pattern: allocate writable, copy, flip to executable, invoke. The `0x3000` is `MEM_COMMIT | MEM_RESERVE`, `0x04` is `PAGE_READWRITE`, `0x20` is `PAGE_EXECUTE_READ`.
-
-Architecture is auto-detected from `$env:PROCESSOR_ARCHITECTURE` — the loader downloads the matching binary from GitHub Releases.
-
 ### In-Process vs Injected Execution
 
 The two Python loader modes represent fundamentally different approaches:

--- a/docs/ARCHITECTURE-MAP.md
+++ b/docs/ARCHITECTURE-MAP.md
@@ -8,7 +8,7 @@ Auto-generated from knowledge graph analysis of 295 source files, 543 code eleme
 
 ```
                     +-----------+
-                    |  Loaders  |  (Python, PowerShell)
+                    |  Loaders  |  (Python)
                     +-----+-----+
                           |
                           | loads .bin
@@ -22,7 +22,7 @@ Auto-generated from knowledge graph analysis of 295 source files, 543 code eleme
                           v
                     +-----------+
                     |  Beacon   |  src/beacon/
-                    |  (6 files)|  Command loop, handlers, shell, screenshots
+                    |  (4 files)|  Command loop, handlers, screenshots
                     +-----+-----+
                           |
                           | uses
@@ -191,15 +191,16 @@ High-level functionality built on Platform.
 
 ---
 
-## Layer Detail: Beacon (6 files)
+## Layer Detail: Beacon (4 files)
 
 The agent itself.
 
 - `main.cc` — `start()` function. Builds handler array, infinite reconnect loop, WebSocket receive-dispatch-respond.
-- `commands.h` — 9 command types, Context struct (holds Shell and ScreenCapture state), CommandHandler typedef.
+- `commands.h` — 11 command types, Context struct (holds ShellManager and ScreenCapture state), CommandHandler typedef.
 - `commandsHandler.cc` — Handler implementations. Wire format structs with `#pragma pack(push, 1)`. UTF-16 path decoding.
-- `shell.h/.cc` — Wraps ShellProcess. Polling read with 5s initial / 100ms subsequent timeout.
 - `screen_capture.h` — Graphics context with dual-buffer (current/previous) for dirty-rect diffing.
+
+**Shell** (`src/lib/shell/`, part of the Lib layer): `shell.h/.cc` — `ShellManager` owns a 256-slot shell pool with beacon-assigned 64-bit ids; wraps ShellProcess. Polling read with 5s initial / 100ms subsequent timeout.
 
 ---
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -8,7 +8,7 @@ Welcome to Position-Independent-Agent. This guide will get you up to speed on th
 
 **What is this?** A cross-platform remote agent written in C++23 that compiles to position-independent, zero-dependency shellcode. Everything — crypto, TLS 1.3, WebSocket, HTTP, DNS, JPEG encoding — is implemented from scratch. No libc, no standard library, no dynamic linking.
 
-**Languages:** C++ (dominant), CMake, linker scripts, Python, PowerShell
+**Languages:** C++ (dominant), CMake, linker scripts, Python
 **Build system:** CMake with custom LLVM compiler pass
 **Targets:** 8 platforms (Windows, Linux, macOS, FreeBSD, Solaris, UEFI, Android, iOS) across 7 architectures (i386, x86_64, armv7a, aarch64, riscv32, riscv64, mips64)
 
@@ -20,21 +20,21 @@ The codebase follows a strict layered architecture. Each layer depends only on l
 
 ```
 +---------------------------------------------------------------+
-|  Beacon (6 files)                                              |
-|  Agent command loop, handlers, shell, screen capture           |
+|  Beacon (4 files)                                              |
+|  Agent command loop, handlers, screen capture                  |
 +---------------------------------------------------------------+
-|  Lib (30 files)                                                |
-|  Crypto, TLS 1.3, HTTP, DNS, WebSocket, JPEG, containers      |
+|  Lib (32 files)                                                |
+|  Crypto, TLS 1.3, HTTP, DNS, WebSocket, JPEG, shell, containers |
 +---------------------------------------------------------------+
-|  Platform (81 files)                                           |
+|  Platform (82 files)                                           |
 |  Console, filesystem, sockets, screen, memory, system utils    |
 |  Per-platform implementations: posix/, windows/, uefi/         |
 +---------------------------------------------------------------+
-|  Kernel (81 files)                                             |
+|  Kernel (88 files)                                             |
 |  Raw syscall definitions and OS API wrappers                   |
 |  Per-OS: linux/, windows/, macos/, freebsd/, solaris/, uefi/   |
 +---------------------------------------------------------------+
-|  Core (31 files)                                               |
+|  Core (32 files)                                               |
 |  Types, memory ops, strings, math, algorithms, compiler RT     |
 +---------------------------------------------------------------+
 ```
@@ -46,7 +46,7 @@ Supporting layers outside the main stack:
 | Build System | 27 | CMake modules, linker scripts, platform configs, post-build verification |
 | Tests | 33 | Test suites for every major subsystem |
 | Tools | 3 | The pic-transform LLVM pass (the core innovation) |
-| Loaders | 2 | Python and PowerShell shellcode loaders |
+| Loaders | 1 | Python shellcode loader |
 | Entry Point | 1 | `src/entry_point.cc` — the bootstrap bridge |
 
 ---
@@ -103,12 +103,12 @@ DNS uses DNS-over-HTTPS (queries via TLS to Cloudflare/Google). `HttpClient` han
 ### 10. The Beacon: Command Loop
 **Read:** `src/beacon/main.cc`, `src/beacon/commands.h`, `src/beacon/commandsHandler.cc`
 
-The beacon is the top-level agent logic. `start()` registers command handlers as a function pointer array, connects via WebSocket to the relay server, and enters a receive-dispatch-respond loop with automatic reconnection. 9 command types: system info, directory listing, file read, file hash, shell I/O (write/read/reset), display enumeration, screenshot. Each handler allocates a response buffer and returns ownership to the caller.
+The beacon is the top-level agent logic. `start()` registers command handlers as a function pointer array, connects via WebSocket to the relay server, and enters a receive-dispatch-respond loop with automatic reconnection. 11 command types: handshake (Hello), directory listing, file read, file hash, shell lifecycle (open/close) and shell I/O (write/read), display enumeration, screenshot, and graceful termination (Exit). Each handler allocates a response buffer and returns ownership to the caller.
 
 ### 11. Shell and Screen Capture
 **Read:** `src/lib/shell/shell.h`, `src/beacon/screen_capture.h`, `src/lib/image/jpeg_encoder.h`
 
-Shell wraps platform `ShellProcess` (PTY on POSIX, cmd.exe pipes on Windows) for interactive remote access. Screen capture uses platform-specific framebuffer reading, binary image differencing for dirty-rectangle detection, and a from-scratch baseline JPEG encoder. Float constants in the DCT are encoded as `UINT32` immediates to stay PIC-compliant.
+Shell wraps platform `ShellProcess` (PTY on POSIX, cmd.exe pipes on Windows) for interactive remote access, managed by `ShellManager` — a 256-slot pool where the beacon assigns each new shell a 64-bit `shellId` (returned by `OpenShell` and reused by `WriteShell`/`ReadShell`/`CloseShell`). Screen capture uses platform-specific framebuffer reading, binary image differencing for dirty-rectangle detection, and a from-scratch baseline JPEG encoder. Float constants in the DCT are encoded as `UINT32` immediates to stay PIC-compliant.
 
 ### 12. The PIC Transform
 **Read:** `tools/pic-transform/PICTransformPass.h`, `tools/pic-transform/PICTransformPass.cpp`
@@ -121,9 +121,9 @@ The key innovation. This custom LLVM pass rewrites compiler IR to eliminate `.da
 The CMake pipeline: freestanding toolchain setup, platform-specific flags and linker scripts that merge all sections into `.text`, PIC transform integration, then post-build steps that extract the `.text` section into a raw binary and verify position-independence by scanning the linker map for forbidden sections. If `.rodata` or `.data` exists, the build fails.
 
 ### 14. Loaders
-**Read:** `loaders/python/loader.py`, `loaders/windows/powershell/loader.ps1`
+**Read:** `loaders/python/loader.py`
 
-The compiled `.bin` is raw machine code. The Python loader auto-detects OS/architecture, downloads the correct binary, and executes via mmap+mprotect on POSIX or process injection (VirtualAllocEx + CreateRemoteThread) on Windows. The PowerShell loader does the same for Windows-only environments. Memory is never simultaneously writable and executable (W^X compliance).
+The compiled `.bin` is raw machine code. The Python loader auto-detects OS/architecture, downloads the correct binary, and executes via mmap+mprotect on POSIX or process injection (VirtualAllocEx + CreateRemoteThread) on Windows. Memory is never simultaneously writable and executable (W^X compliance).
 
 ---
 
@@ -195,20 +195,20 @@ These files are the most complex in the codebase. Approach them with care (and c
 | `src/core/binary/binary_reader.h` | Sequential byte reading with big-endian support |
 | `src/core/binary/binary_writer.h` | Sequential byte writing with big-endian support |
 
-### Beacon (6 files)
+### Beacon (4 files)
 | File | What it does |
 |------|-------------|
 | `src/beacon/main.cc` | WebSocket connect, receive-dispatch-respond loop |
 | `src/beacon/commands.h` | CommandType enum, Context struct, handler typedef |
-| `src/beacon/commandsHandler.cc` | All 9 command handlers |
-| `src/lib/shell/shell.h` / `shell.cc` | Interactive shell wrapper |
+| `src/beacon/commandsHandler.cc` | All 11 command handlers |
 | `src/beacon/screen_capture.h` | Screen capture data structures and dirty-rect state |
 
-### Lib (30 files)
+### Lib (32 files)
 | File | What it does |
 |------|-------------|
 | `src/lib/runtime.h` | Aggregate include for entire runtime |
 | `src/lib/vector.h` | Move-only dynamic array with fallible allocation |
+| `src/lib/shell/shell.h` / `shell.cc` | Interactive shell wrapper and `ShellManager` pool |
 | `src/lib/crypto/chacha20.*` | ChaCha20-Poly1305 AEAD cipher (RFC 8439) |
 | `src/lib/crypto/ecc.*` | ECDH key exchange, P-256/P-384 |
 | `src/lib/crypto/sha2.*` | SHA-256/SHA-384 and HMAC |

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -19,24 +19,24 @@ Welcome to Position-Independent-Agent. This guide will get you up to speed on th
 The codebase follows a strict layered architecture. Each layer depends only on layers below it — never sideways or upward.
 
 ```
-+---------------------------------------------------------------+
++----------------------------------------------------------------+
 |  Beacon (4 files)                                              |
 |  Agent command loop, handlers, screen capture                  |
-+---------------------------------------------------------------+
++----------------------------------------------------------------+
 |  Lib (32 files)                                                |
-|  Crypto, TLS 1.3, HTTP, DNS, WebSocket, JPEG, shell, containers |
-+---------------------------------------------------------------+
+|  Crypto, TLS 1.3, HTTP, DNS, WebSocket, JPEG, shell, containers|
++----------------------------------------------------------------+
 |  Platform (82 files)                                           |
 |  Console, filesystem, sockets, screen, memory, system utils    |
 |  Per-platform implementations: posix/, windows/, uefi/         |
-+---------------------------------------------------------------+
++----------------------------------------------------------------+
 |  Kernel (88 files)                                             |
 |  Raw syscall definitions and OS API wrappers                   |
 |  Per-OS: linux/, windows/, macos/, freebsd/, solaris/, uefi/   |
-+---------------------------------------------------------------+
++----------------------------------------------------------------+
 |  Core (32 files)                                               |
 |  Types, memory ops, strings, math, algorithms, compiler RT     |
-+---------------------------------------------------------------+
++----------------------------------------------------------------+
 ```
 
 Supporting layers outside the main stack:
@@ -208,7 +208,7 @@ These files are the most complex in the codebase. Approach them with care (and c
 |------|-------------|
 | `src/lib/runtime.h` | Aggregate include for entire runtime |
 | `src/lib/vector.h` | Move-only dynamic array with fallible allocation |
-| `src/lib/shell/shell.h` / `shell.cc` | Interactive shell wrapper and `ShellManager` pool |
+| `src/lib/shell/shell.*` | Interactive shell wrapper and `ShellManager` pool |
 | `src/lib/crypto/chacha20.*` | ChaCha20-Poly1305 AEAD cipher (RFC 8439) |
 | `src/lib/crypto/ecc.*` | ECDH key exchange, P-256/P-384 |
 | `src/lib/crypto/sha2.*` | SHA-256/SHA-384 and HMAC |

--- a/src/README.md
+++ b/src/README.md
@@ -39,7 +39,7 @@ Build-unique DJB2 seeding via FNV-1a, lookup-table-free Base64, UTF-8/UTF-16 sur
 - [Memory](platform/memory/README.md) — Size-header trick for `munmap`, `mmap2` page-shift, FreeBSD i386 inline asm
 - [Screen](platform/screen/README.md) — Linux three-tier capture (X11→DRM→fbdev), macOS fork-based crash isolation
 - [Socket](platform/socket/README.md) — Windows AFD driver, UEFI busy-poll async, i386 socketcall multiplexer
-- [System](platform/system/README.md) — 5 PTY creation variants, PEB environment walking, SMBIOS UUID
+- [System](platform/system/README.md) — 4 PTY creation variants, PEB environment walking, SMBIOS UUID
 
 ### Layer 2: Kernel Interfaces
 

--- a/src/beacon/README.md
+++ b/src/beacon/README.md
@@ -22,14 +22,17 @@ Top-level application layer — connects to a relay server over WebSocket (TLS 1
 │       │                                                     │
 │  ┌────┴─────────────────────────────────────────────────┐   │
 │  │              Command Handlers                        │   │
-│  ├─ Hello               → SystemInfo struct             │   │
+│  ├─ Hello               → SystemInfo, build info + mask │   │
 │  ├─ GetDirectoryContent → DirectoryIterator             │   │
 │  ├─ GetFileContent      → File::Open + Read             │   │
-│  ├─ WriteShell          → ShellProcess::Write           │   │
-│  ├─ ReadShell           → ShellProcess::Read            │   │
+│  ├─ GetFileChunkHash    → File read + SHA-256           │   │
+│  ├─ OpenShell           → ShellManager::Open            │   │
+│  ├─ WriteShell          → Shell::Write                  │   │
+│  ├─ ReadShell           → Shell::Read                   │   │
+│  ├─ CloseShell          → ShellManager::Close           │   │
 │  ├─ GetDisplays         → Screen::GetDevices            │   │
 │  ├─ GetScreenshot       → Screen::Capture + JPEG encode │   │
-│  └─ Exit                → graceful ExitProcess          │   │
+│  └─ Exit                → shouldExit, ACK + teardown    │   │
 │                                                             │
 └──────────────────────┬──────────────────────────────────────┘
                        │
@@ -40,6 +43,8 @@ Top-level application layer — connects to a relay server over WebSocket (TLS 1
 ```
 
 ## Connection Pipeline
+
+The relay URL is read at startup from the `R_URL` environment variable; there is no fallback — the agent exits if `R_URL` is unset.
 
 Full protocol stack, all implemented in-process:
 
@@ -67,20 +72,35 @@ Every layer implemented from scratch in `src/lib/` — no OpenSSL, no libcurl, n
 
 ## Command Dispatch
 
-Commands are dispatched via a function pointer array indexed by command type:
+Commands are dispatched via a function pointer array indexed by command type. Each handler receives the raw payload, returns a heap-allocated response buffer, and shares state through a stack-allocated `Context` (PIC-safe — no globals):
 
-```c
-typedef Result<void, Error> (*CommandHandler)(WebSocketClient&, Span<UINT8> payload);
-CommandHandler handlers[] = {
-    HandleHello,                // 0
-    HandleGetDirectoryContent,  // 1
-    HandleGetFileContent,       // 2
-    HandleWriteShell,           // 3
-    HandleReadShell,            // 4
-    HandleGetDisplays,          // 5
-    HandleGetScreenshot,        // 6
-};
+```cpp
+using CommandHandler = VOID (*)(PCHAR command, USIZE commandLength,
+                                PPCHAR response, PUSIZE responseLength,
+                                Context *context);
+
+CommandHandler commandHandlers[CommandType::CommandTypeCount] = {nullptr};
+// Core (mandatory, always registered)
+commandHandlers[CommandType::Command_Hello] = Handle_HelloCommand;
+commandHandlers[CommandType::Command_Exit]  = Handle_ExitCommand;
+#if SUPPORT_FILESYSTEM
+commandHandlers[CommandType::Command_GetDirectoryContent] = Handle_GetDirectoryContentCommand;
+commandHandlers[CommandType::Command_GetFileContent]      = Handle_GetFileContentCommand;
+commandHandlers[CommandType::Command_GetFileChunkHash]    = Handle_GetFileChunkHashCommand;
+#endif
+#if SUPPORT_SHELL
+commandHandlers[CommandType::Command_OpenShell]  = Handle_OpenShellCommand;
+commandHandlers[CommandType::Command_CloseShell] = Handle_CloseShellCommand;
+commandHandlers[CommandType::Command_ReadShell]  = Handle_ReadShellCommand;
+commandHandlers[CommandType::Command_WriteShell] = Handle_WriteShellCommand;
+#endif
+#if SUPPORT_DISPLAY
+commandHandlers[CommandType::Command_GetDisplays]   = Handle_GetDisplaysCommand;
+commandHandlers[CommandType::Command_GetScreenshot] = Handle_GetScreenshotCommand;
+#endif
 ```
+
+`Hello` and `Exit` are mandatory core commands. Each other group is compiled in only when its `SUPPORT_<CATEGORY>` macro is set (default `1`); compiled-out commands answer with `StatusUnknownCommand`.
 
 ### Command: GetScreenshot
 
@@ -100,14 +120,16 @@ Screen::Capture(device, rgbBuffer)     → raw RGB pixels
 
 The JPEG encoder streams output via callback — no intermediate buffer for the full compressed image.
 
-### Command: Shell (Write/Read)
+### Command: Shell (Open/Write/Read/Close)
 
-Interactive shell access using the platform's `ShellProcess`:
+Interactive shell sessions managed by `ShellManager` (`src/lib/shell/shell.h`). The beacon owns a 256-slot shell pool; `OpenShell` spawns a shell in the first free slot and returns the assigned 64-bit `shellId`, which the client must reuse for `WriteShell`/`ReadShell`/`CloseShell` (errors: `Shell_NoFreeSlot` when the pool is full, `ShellProcess_CreateFailed` when spawning fails). `CloseShell` is idempotent and frees the slot for reuse; read/write errors never auto-close the session.
 
-- **POSIX**: `/bin/sh` running in a PTY (single fd for stdin+stdout)
-- **Windows**: `cmd.exe` with three anonymous pipes (stdin, stdout, stderr)
+The underlying `ShellProcess` per platform:
 
-`WriteShell` sends operator input to the shell's stdin. `ReadShell` polls for output and returns whatever is available (non-blocking via `Poll`).
+- **POSIX**: `/bin/sh` on a PTY, which multiplexes stdin/stdout/stderr on a single fd
+- **Windows**: `cmd.exe` over two anonymous pipes (stdin, stdout) with stderr redirected into the stdout pipe — mirroring the single-stream POSIX PTY and ensuring stderr is actually drained (a separate, never-read stderr pipe would fill its buffer and stall `cmd.exe`)
+
+`WriteShell` sends operator input to the shell's stdin. `ReadShell` polls for output (5000 ms initial timeout, then 100 ms) and returns whatever is available, stopping early at the shell prompt character.
 
 ## Entry Point
 

--- a/src/platform/README.md
+++ b/src/platform/README.md
@@ -34,7 +34,7 @@ Cross-platform abstraction providing OS-independent interfaces for I/O, networki
 - [Memory](memory/README.md) — Size-header trick for `munmap`, `mmap2` page-shift, FreeBSD i386 inline asm for 64-bit `off_t`
 - [Screen](screen/README.md) — Linux three-tier capture (X11→DRM→fbdev), macOS fork-based CoreGraphics probing, UEFI GOP
 - [Socket](socket/README.md) — Windows AFD driver networking, i386 `socketcall` multiplexer, UEFI busy-poll TCP, BSD `sin_len`
-- [System](system/README.md) — 5 PTY creation variants, PEB environment walking, SMBIOS UUID, `fork`+`execve` process model
+- [System](system/README.md) — 4 PTY creation variants, PEB environment walking, SMBIOS UUID, `fork`+`execve` process model
 
 ## Kernel Interfaces
 

--- a/src/platform/system/README.md
+++ b/src/platform/system/README.md
@@ -235,6 +235,8 @@ si.hStdError = stderrWrite;
 CreateProcessW(path, cmdLine, ..., TRUE /*inherit*/, ..., &si, &pi)
 ```
 
+The generic `Process::Create` accepts three independent handles — the three-pipe layout above is the fully-wired case. `ShellProcess` deliberately deviates: it creates only two pipes and passes the **same** stdout write-end as the stderr handle (see the next section).
+
 ## Interactive Shell
 
 ### POSIX: Shell over PTY
@@ -252,7 +254,7 @@ Single fd for all I/O — the PTY multiplexes stdin/stdout/stderr.
 
 ### Windows: cmd.exe over Two Pipes (stderr merged)
 
-Windows lacks PTY support, so `cmd.exe` runs over two anonymous pipes (stdin, stdout) with stderr redirected into the stdout pipe — mirroring the single-stream POSIX PTY and ensuring stderr is actually drained (a separate, never-read stderr pipe would fill its buffer and stall `cmd.exe`). `PeekNamedPipe` provides non-blocking read capability for polling.
+Windows lacks PTY support, so `cmd.exe` runs over two anonymous pipes (stdin, stdout). In `ShellProcess::Create` (`src/platform/system/windows/shell_process.cc`), the stdout pipe's write-end is passed as **both** `hStdOutput` and `hStdError`, merging the streams — mirroring the single-stream POSIX PTY and ensuring stderr is actually drained (a separate, never-read stderr pipe would fill its buffer and stall `cmd.exe`). `PeekNamedPipe` provides non-blocking read capability for polling.
 
 End-of-prompt detection: `'>'` on Windows (cmd.exe), `'$'` on POSIX (sh).
 

--- a/src/platform/system/README.md
+++ b/src/platform/system/README.md
@@ -143,7 +143,7 @@ The `Environment` class provides compile-time and runtime system identification 
 
 ## Pseudo-Terminal (PTY) Creation
 
-PTY creation is the most platform-divergent operation in the runtime, with **five different flows** across POSIX platforms:
+PTY creation is the most platform-divergent operation in the runtime, with **four different flows** across POSIX platforms:
 
 ### Linux/Android
 
@@ -250,9 +250,9 @@ fork()
 
 Single fd for all I/O — the PTY multiplexes stdin/stdout/stderr.
 
-### Windows: cmd.exe over Three Pipes
+### Windows: cmd.exe over Two Pipes (stderr merged)
 
-Windows lacks PTY support, so three separate anonymous pipes handle stdin, stdout, and stderr independently. `PeekNamedPipe` provides non-blocking read capability for polling.
+Windows lacks PTY support, so `cmd.exe` runs over two anonymous pipes (stdin, stdout) with stderr redirected into the stdout pipe — mirroring the single-stream POSIX PTY and ensuring stderr is actually drained (a separate, never-read stderr pipe would fill its buffer and stall `cmd.exe`). `PeekNamedPipe` provides non-blocking read capability for polling.
 
 End-of-prompt detection: `'>'` on Windows (cmd.exe), `'$'` on POSIX (sh).
 
@@ -269,5 +269,5 @@ End-of-prompt detection: `'>'` on Windows (cmd.exe), `'$'` on POSIX (sh).
 | OSVersion | PEB version fields | `uname`/`sysctl`/`utssys`+`/etc/release` | `"uefi"` |
 | Pipe | `CreatePipe` | `pipe()`/`pipe2()` | Not supported |
 | Process | `CreateProcessW` | `fork()`+`execve()` | Not supported |
-| PTY | Not supported | `/dev/ptmx` (5 variants) | Not supported |
-| Shell | `cmd.exe` + 3 pipes | `/bin/sh` + PTY | Not supported |
+| PTY | Not supported | `/dev/ptmx` (4 variants) | Not supported |
+| Shell | `cmd.exe` + 2 pipes (stderr merged) | `/bin/sh` + PTY | Not supported |

--- a/tools/pic-transform/README.md
+++ b/tools/pic-transform/README.md
@@ -37,7 +37,7 @@ clang++ -fpass-plugin=./PICTransform.so -O2 input.cpp -o output
 
 ### Requirements
 
-- LLVM 20+ development headers and libraries
+- LLVM 22+ development headers and libraries
 - CMake 3.20+
 - Ninja or Make
 


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes (1-3 sentences) -->
This pull request updates the documentation to reflect recent changes in the command set, platform support, and project structure. The most significant updates are the addition of the `Exit` command, the renaming and clarification of shell command types, the removal of the PowerShell loader, and the update of test suite counts and platform implementation details.

## Type of Change

- [ ] Bug fix
- [ ] New feature / command
- [ ] Refactoring (no functional changes)
- [x] Documentation
- [ ] Build system / CI
- [ ] Other:

## Platforms Tested

<!-- List the platform-architecture presets you built and tested against -->

- [ ] `windows-x86_64-release`
- [ ] `linux-x86_64-release`
- [ ] `macos-aarch64-release`
- [ ] Other:

## Binary Size Impact

<!-- Required: Report .text section size before and after your change for at least one preset -->
<!-- Use: llvm-size build/release/<platform>/<arch>/output.exe -->

No impact.

## Checklist

- [ ] Build passes with no warnings for at least one preset
- [ ] Post-build PIC verification passes (no `.rdata`/`.rodata`/`.data`/`.bss` sections)
- [ ] Code follows [naming conventions](CONTRIBUTING.md#naming-conventions) and [code style](CONTRIBUTING.md#code-style)
- [ ] Doxygen documentation added for new public APIs
- [ ] No STL, no exceptions, no RTTI
- [ ] `Result<T, Error>` used for all fallible functions
- [ ] Binary size diff reported above
- [ ] README updated (if adding/modifying commands)

## Additional Notes

<!-- Any context, design decisions, trade-offs, or related issues -->
