### PR TITLE
Fix missing header

### DIFF
--- a/docs/13-beacon.md
+++ b/docs/13-beacon.md
@@ -438,7 +438,7 @@ private:
 public:
     static Result<Shell, Error> Create() noexcept;
     Result<USIZE, Error> Write(const char *data, USIZE length) noexcept;
-    Result<USIZE, Error> Read(char *buffer, USIZE capacity) noexcept;
+    Result<USIZE, Error> Read(PCHAR buffer, USIZE capacity) noexcept;
     ~Shell() noexcept;
 };
 ```

--- a/src/lib/shell/shell.cc
+++ b/src/lib/shell/shell.cc
@@ -21,7 +21,7 @@ Result<USIZE, Error> Shell::Write(const char *data, USIZE length) noexcept
     return shellProcess.Write(data, length);
 }
 
-Result<USIZE, Error> Shell::Read(char *buffer, USIZE capacity) noexcept
+Result<USIZE, Error> Shell::Read(PCHAR buffer, USIZE capacity) noexcept
 {
     USIZE totalRead = 0;
 

--- a/src/lib/shell/shell.h
+++ b/src/lib/shell/shell.h
@@ -11,7 +11,7 @@ private:
 public:
     static Result<Shell, Error> Create() noexcept;
     Result<USIZE, Error> Write(const char *data, USIZE length) noexcept;
-    Result<USIZE, Error> Read(char *buffer, USIZE capacity) noexcept;
+    Result<USIZE, Error> Read(PCHAR buffer, USIZE capacity) noexcept;
 
     ~Shell() noexcept = default;
     Shell(Shell &&other) noexcept;

--- a/src/platform/system/windows/environment.cc
+++ b/src/platform/system/windows/environment.cc
@@ -10,6 +10,7 @@
 #include "platform/kernel/windows/peb.h"
 #include "core/memory/memory.h"
 #include "core/string/string.h"
+#include "platform/kernel/windows/windows_types.h"
 
 // Extended RTL_USER_PROCESS_PARAMETERS with Environment field
 // The standard definition in peb.h doesn't include all fields


### PR DESCRIPTION
This pull request adds an additional include to the `src/platform/system/windows/environment.cc` file to ensure that Windows-specific type definitions are available.

* Added `#include "platform/kernel/windows/windows_types.h"` to provide necessary Windows type definitions.