### PR TITLE
Detect host CPU architecture at runtime and report OS name

### DIFF
--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -5680,7 +5680,7 @@
       "type": "file",
       "name": "environment.cc (POSIX)",
       "filePath": "src/platform/system/posix/environment.cc",
-      "summary": "POSIX Environment implementation: GetVariable reads /proc/self/environ on Linux/Android (stub on other POSIX); GetAgentPlatform/GetArchitecture return compile-time strings; GetOSVersion uses uname/sysctl/utssys; GetHostname uses env vars, sysctl, or /etc/hostname.",
+      "summary": "POSIX Environment implementation: GetVariable reads /proc/self/environ on Linux/Android (stub on other POSIX); GetAgentPlatform returns the compile-time string, GetArchitecture runtime-detects the host CPU (uname/sysctl hw.machine/sysinfo, compile-time fallback); GetOSVersion uses uname/sysctl/utssys; GetHostname uses env vars, sysctl, or /etc/hostname.",
       "tags": [
         "environment",
         "posix",

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ beacon supports.
 | `MachineUUID`   | `UUID` (16B) | Hardware/OS-level unique identifier                                 |
 | `Hostname`      | `CHAR[256]`  | Machine hostname (from env or `/etc/hostname`)                      |
 | `Username`      | `CHAR[256]`  | Current user name (env, `getuid()`+`/etc/passwd`, or numeric uid)    |
-| `Architecture`  | `CHAR[32]`   | CPU architecture (`x86_64`, `aarch64`, etc.) — compile-time         |
+| `Architecture`  | `CHAR[32]`   | Host CPU architecture, OS-provided name verbatim (`x86_64`, `arm64`, `amd64`, ...) — runtime-detected (compile-time fallback); reports the real host under WOW64/emulation; iOS/UEFI and detection failures use the compile-time target |
 | `AgentPlatform` | `CHAR[32]`   | OS target (`windows`, `linux`, `macos`, etc.) — compile-time        |
 | `OSVersion`     | `CHAR[128]`  | Runtime OS version (`Windows 10.0 Build 19045`, `Linux 6.1.0`)     |
 

--- a/docs/dashboard/knowledge-graph.json
+++ b/docs/dashboard/knowledge-graph.json
@@ -5680,7 +5680,7 @@
       "type": "file",
       "name": "environment.cc (POSIX)",
       "filePath": "src/platform/system/posix/environment.cc",
-      "summary": "POSIX Environment implementation: GetVariable reads /proc/self/environ on Linux/Android (stub on other POSIX); GetAgentPlatform/GetArchitecture return compile-time strings; GetOSVersion uses uname/sysctl/utssys; GetHostname uses env vars, sysctl, or /etc/hostname.",
+      "summary": "POSIX Environment implementation: GetVariable reads /proc/self/environ on Linux/Android (stub on other POSIX); GetAgentPlatform returns the compile-time string, GetArchitecture runtime-detects the host CPU (uname/sysctl hw.machine/sysinfo, compile-time fallback); GetOSVersion uses uname/sysctl/utssys; GetHostname uses env vars, sysctl, or /etc/hostname.",
       "tags": [
         "environment",
         "posix",

--- a/src/core/types/error.h
+++ b/src/core/types/error.h
@@ -248,6 +248,13 @@ struct Error
 		ShellProcess_NotSupported = 136, // shell not supported on this platform
 		ShellProcess_ReadFailed = 137,	  // shell read failed
 		Shell_NoFreeSlot = 138,          // all shell slots in use
+
+		// -------------------------
+		// Kernel32 WOW64 query errors (139–141)
+		// -------------------------
+		Kernel32_ExportUnavailable = 139, // IsWow64Process2/IsWow64Process export not present (pre-Windows 10 1511 / pre-XP)
+		Kernel32_IsWow64ProcessFailed = 140, // IsWow64Process query failed
+		Kernel32_IsWow64Process2Failed = 141, // IsWow64Process2 query failed
 	};
 
 	/**

--- a/src/platform/kernel/solaris/syscall.h
+++ b/src/platform/kernel/solaris/syscall.h
@@ -47,6 +47,9 @@ constexpr USIZE SYS_GETDENTS64 = 213;  // ILP32 only: 64-bit dirent for 32-bit p
 
 // System information
 constexpr USIZE SYS_UTSSYS     = 57;   // utssys(buf, arg, type): type 0 = uname
+constexpr USIZE SYS_SYSINFO    = 139;  // sysinfo(cmd, buf, count)
+constexpr USIZE SI_ARCHITECTURE_64 = 517; // sysinfo cmd: kernel 64-bit instruction set name
+constexpr USIZE SI_ARCHITECTURE_32 = 516; // sysinfo cmd: kernel 32-bit instruction set name
 
 // I/O control
 constexpr USIZE SYS_IOCTL      = 54;

--- a/src/platform/kernel/windows/kernel32.cc
+++ b/src/platform/kernel/windows/kernel32.cc
@@ -43,3 +43,27 @@ Result<VOID, Error> Kernel32::PeekNamedPipe(SSIZE hNamedPipe, PVOID lpBuffer, UI
 	}
 	return Result<VOID, Error>::Ok();
 }
+
+Result<VOID, Error> Kernel32::IsWow64Process2(PVOID hProcess, PUINT16 lpProcessMachine, PUINT16 lpNativeMachine)
+{
+	// kernel32 exports IsWow64Process2 as a forwarder to the api-ms-win-core-wow64
+	// API set hosted by kernelbase.dll; GetExportAddress follows the forwarder
+	// (loading the target if needed). Pre-Windows 10 1511 builds export it
+	// nowhere, so resolution fails and the caller falls back.
+	auto fn = (BOOL(STDCALL *)(PVOID hProcess, PUINT16 lpProcessMachine, PUINT16 lpNativeMachine))ResolveKernel32ExportAddress("IsWow64Process2");
+	if (fn == nullptr)
+		return Result<VOID, Error>::Err(Error(Error::Kernel32_ExportUnavailable));
+	if (!fn(hProcess, lpProcessMachine, lpNativeMachine))
+		return Result<VOID, Error>::Err(Error(Error::Kernel32_IsWow64Process2Failed));
+	return Result<VOID, Error>::Ok();
+}
+
+Result<VOID, Error> Kernel32::IsWow64Process(PVOID hProcess, PUINT32 lpWow64Process)
+{
+	auto fn = (BOOL(STDCALL *)(PVOID hProcess, PUINT32 lpWow64Process))ResolveKernel32ExportAddress("IsWow64Process");
+	if (fn == nullptr)
+		return Result<VOID, Error>::Err(Error(Error::Kernel32_ExportUnavailable));
+	if (!fn(hProcess, lpWow64Process))
+		return Result<VOID, Error>::Err(Error(Error::Kernel32_IsWow64ProcessFailed));
+	return Result<VOID, Error>::Ok();
+}

--- a/src/platform/kernel/windows/kernel32.h
+++ b/src/platform/kernel/windows/kernel32.h
@@ -194,4 +194,64 @@ public:
 	 * https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-peeknamedpipe
 	 */
 	[[nodiscard]] static Result<VOID, Error> PeekNamedPipe(SSIZE hNamedPipe, PVOID lpBuffer, UINT32 nBufferSize, PUINT32 lpBytesRead, PUINT32 lpTotalBytesAvail, PUINT32 lpBytesLeftThisMessage);
+
+	/**
+	 * @brief Determines whether the specified process is running under WOW64.
+	 *
+	 * @details Reports the machine architectures of the target process and the
+	 * host operating system. When the process is not running under WOW64,
+	 * *lpProcessMachine is set to IMAGE_FILE_MACHINE_UNKNOWN and *lpNativeMachine
+	 * receives the host architecture. When it is running under WOW64 (e.g. an
+	 * x86 process on x64, or an x86/x64 process on ARM64 emulation),
+	 * *lpProcessMachine receives the architecture the process was built for.
+	 * Used to report the real host CPU architecture regardless of the
+	 * architecture the agent was compiled for.
+	 *
+	 * @param hProcess Handle to the process to query (NtCurrentProcess() for self).
+	 * @param lpProcessMachine Receives the architecture of the target process
+	 *                         (IMAGE_FILE_MACHINE_UNKNOWN if not under WOW64).
+	 * @param lpNativeMachine Receives the architecture of the host operating system.
+	 *
+	 * @return Result<VOID, Error> Ok() on success; Err(Kernel32_ExportUnavailable)
+	 *         if the export is missing (pre-Windows 10 1511, where the export
+	 *         exists in no module); Err(Kernel32_IsWow64Process2Failed) if the
+	 *         call itself failed.
+	 *
+	 * @note Resolved from kernel32.dll; the export is a forwarder into the
+	 *       api-ms-win-core-wow64 API set, which GetExportAddress follows
+	 *       (loading the host DLL if it is not already mapped).
+	 *
+	 * @par Requirements
+	 * Minimum supported client: Windows 10 version 1511 [desktop apps | UWP apps]
+	 * Minimum supported server: Windows Server 2016
+	 *
+	 * @see Microsoft Learn -- IsWow64Process2 function
+	 *      https://learn.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process2
+	 */
+	[[nodiscard]] static Result<VOID, Error> IsWow64Process2(PVOID hProcess, PUINT16 lpProcessMachine, PUINT16 lpNativeMachine);
+
+	/**
+	 * @brief Determines whether the specified process is running under WOW64.
+	 *
+	 * @details Legacy single-bit query: sets *lpWow64Process to TRUE when the
+	 * 32-bit target process is running inside the x64 WOW64 emulator. Used as
+	 * the fallback for IsWow64Process2() on pre-Windows 10 1511 systems, where
+	 * a TRUE result implies an x64 host (the ARM64 WOW64 emulator post-dates
+	 * this export).
+	 *
+	 * @param hProcess Handle to the process to query (NtCurrentProcess() for self).
+	 * @param lpWow64Process Receives TRUE when the process runs under WOW64.
+	 *
+	 * @return Result<VOID, Error> Ok() on success; Err(Kernel32_ExportUnavailable)
+	 *         if the export is missing (pre-Windows XP); Err(Kernel32_IsWow64ProcessFailed)
+	 *         if the call itself failed.
+	 *
+	 * @par Requirements
+	 * Minimum supported client: Windows XP with SP2 [desktop apps | UWP apps]
+	 * Minimum supported server: Windows Server 2003 with SP1
+	 *
+	 * @see Microsoft Learn -- IsWow64Process function
+	 *      https://learn.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process
+	 */
+	[[nodiscard]] static Result<VOID, Error> IsWow64Process(PVOID hProcess, PUINT32 lpWow64Process);
 };

--- a/src/platform/kernel/windows/pe.cc
+++ b/src/platform/kernel/windows/pe.cc
@@ -2,6 +2,26 @@
 #include "platform/kernel/windows/peb.h"
 #include "platform/kernel/windows/ntdll.h"
 #include "core/algorithms/djb2.h"
+#include "core/string/string.h"
+
+// Load a module by wide base name (e.g. L"kernelbase.dll",
+// L"api-ms-win-core-wow64-l1-1-0.dll") via LdrLoadDll and return its base
+// address. API-set names name no real DLL, but the loader understands them
+// natively and maps them onto the host DLL (usually kernelbase.dll).
+static PVOID LoadForwardedModule(const WCHAR *moduleName) noexcept
+{
+	UNICODE_STRING dllName;
+	UINT16 nameLen = (UINT16)StringUtils::Length(moduleName);
+	dllName.Length = nameLen * sizeof(WCHAR);
+	dllName.MaximumLength = dllName.Length + sizeof(WCHAR);
+	dllName.Buffer = (PWCHAR)moduleName;
+
+	PVOID moduleBase = nullptr;
+	auto r = NTDLL::LdrLoadDll(nullptr, nullptr, &dllName, &moduleBase);
+	if (!r || moduleBase == nullptr)
+		return nullptr;
+	return moduleBase;
+}
 
 // Get the address of an exported function from a module base address
 PVOID GetExportAddress(PVOID hModule, UINT64 functionNameHash)
@@ -79,6 +99,15 @@ PVOID GetExportAddress(PVOID hModule, UINT64 functionNameHash)
 
 				// Get the target module base address from the PEB and validate it
 				PVOID targetModule = GetModuleHandleFromPEB(targetModuleHash);
+
+				// Not loaded: load it. The forwarder names its target ("NTDLL.RtlRandomEx",
+				// "api-ms-win-core-wow64.IsWow64Process2"); LdrLoadDll resolves both real
+				// DLL names and API-set schema names onto the host DLL. API-set names
+				// never map back onto the forwarding module itself, so recursion
+				// terminates.
+				if (targetModule == nullptr)
+					targetModule = LoadForwardedModule(wideModuleName);
+
 				if (targetModule == nullptr)
 					return nullptr;
 

--- a/src/platform/kernel/windows/pe.h
+++ b/src/platform/kernel/windows/pe.h
@@ -264,6 +264,17 @@ typedef struct _IMAGE_DOS_HEADER
 #define IMAGE_NT_SIGNATURE 0x00004550  ///< "PE\0\0" NT signature
 #define IMAGE_DIRECTORY_ENTRY_EXPORT 0 ///< Index of the export directory in the data directory array
 
+/// @brief Unknown or corrupted machine type (IsWow64Process2: not running under WOW64)
+#define IMAGE_FILE_MACHINE_UNKNOWN 0x0000
+/// @brief Intel 386 (or later) processor architecture
+#define IMAGE_FILE_MACHINE_I386 0x014C
+/// @brief ARM Thumb-2 processor architecture
+#define IMAGE_FILE_MACHINE_ARMNT 0x01C4
+/// @brief x64 (AMD64 / x86-64) processor architecture
+#define IMAGE_FILE_MACHINE_AMD64 0x8664
+/// @brief ARM64 processor architecture
+#define IMAGE_FILE_MACHINE_ARM64 0xAA64
+
 /**
  * @brief Resolves an exported function address from a loaded PE module by name hash.
  *

--- a/src/platform/system/README.md
+++ b/src/platform/system/README.md
@@ -133,13 +133,16 @@ On Linux/Android the runtime reads `/proc/self/environ` — a null-terminated bl
 
 The `Environment` class provides compile-time and runtime system identification via `GetAgentPlatform()`, `GetOSVersion()`, `GetHostname()`, `GetUsername()`, and `GetArchitecture()`.
 
-| Platform | OS Version Source | Hostname Source | Username Source |
-|---|---|---|---|
-| **Windows** | PEB `OSMajorVersion`/`OSMinorVersion`/`OSBuildNumber` | `COMPUTERNAME` env var | `USERNAME` env var |
-| **Linux/Android** | `uname` syscall | `HOSTNAME` env var / `/etc/hostname` | `USER`/`LOGNAME` env → uid (`/proc/self/status`) + `/etc/passwd` |
-| **macOS/iOS/FreeBSD** | `sysctl` (kern.ostype + kern.osrelease) | `sysctl` kern.hostname | `getuid()` + `/etc/passwd` (numeric uid if not in passwd) |
-| **Solaris** | `utssys` → `/etc/release` fallback | `utssys` nodename → `/etc/nodename` | `getuid()` + `/etc/passwd` |
-| **UEFI** | `"uefi"` (static) | empty (no hostname concept) | empty (no user concept) |
+| Platform | OS Version Source | Hostname Source | Username Source | Architecture Source |
+|---|---|---|---|---|
+| **Windows** | PEB `OSMajorVersion`/`OSMinorVersion`/`OSBuildNumber` | `COMPUTERNAME` env var | `USERNAME` env var | `IsWow64Process2` native machine (Win10 1511+); `IsWow64Process` → amd64 pre-1511 |
+| **Linux/Android** | `uname` syscall | `HOSTNAME` env var / `/etc/hostname` | `USER`/`LOGNAME` env → uid (`/proc/self/status`) + `/etc/passwd` | `uname` machine field |
+| **macOS/FreeBSD** | `sysctl` (kern.ostype + kern.osrelease) | `sysctl` kern.hostname | `getuid()` + `/etc/passwd` (numeric uid if not in passwd) | `sysctl` `hw.machine` |
+| **Solaris** | `utssys` → `/etc/release` fallback | `utssys` nodename → `/etc/nodename` | `getuid()` + `/etc/passwd` | `sysinfo` SI_ARCHITECTURE_64 → 32 |
+| **iOS** | `sysctl` (kern.ostype + kern.osrelease) | `sysctl` kern.hostname | `getuid()` + `/etc/passwd` | compile-time (`hw.machine` is a device model, not an arch) |
+| **UEFI** | `"uefi"` (static) | empty (no hostname concept) | empty (no user concept) | compile-time |
+
+Architecture detection reports the **real host CPU** even when the agent runs emulated (x86 agent under WOW64 on x64/ARM64, i386 agent on an x86_64 kernel). The OS-provided machine name is reported **verbatim** — no renaming or normalization (`uname` says `armv7l`, the agent reports `armv7l`; Windows reports `amd64`/`arm64`/`i386`/`arm` per the native machine code; macOS/FreeBSD report `arm64`/`x86_64`/...). When detection fails, the compile-time `ARCHITECTURE_*` string is used as fallback. Caveats: a Linux process with a 32-bit personality (`setarch`/`linux32`) or in some containers sees the personality's machine name (`i686`); a Rosetta 2 process on macOS reports the emulated `x86_64`; iOS reports the compile-time target because `hw.machine` returns hardware model identifiers (`iPhone13,2`).
 
 ## Pseudo-Terminal (PTY) Creation
 

--- a/src/platform/system/environment.h
+++ b/src/platform/system/environment.h
@@ -14,7 +14,8 @@
  * - GetOSVersion(): runtime OS version string (e.g. "Windows 10.0 Build 19045")
  * - GetHostname(): machine hostname from OS environment
  * - GetUsername(): current user name (env, getuid()+/etc/passwd, or numeric uid)
- * - GetArchitecture(): compile-time CPU architecture string (e.g. "x86_64")
+ * - GetArchitecture(): runtime host CPU architecture string (e.g. "x86_64"),
+ *   falling back to the compile-time target when OS detection is unavailable
  */
 
 #pragma once
@@ -102,14 +103,27 @@ public:
 	[[nodiscard]] static Result<USIZE, Error> GetUsername(Span<CHAR> buffer) noexcept;
 
 	/**
-	 * @brief Retrieves the compile-time CPU architecture string.
+	 * @brief Retrieves the runtime host CPU architecture string.
 	 *
 	 * @param buffer Output buffer to receive the architecture string.
 	 * @return Length of the string written (excluding null terminator).
 	 *
-	 * @details Returns a short identifier for the CPU architecture the agent
-	 * was compiled for (e.g. "x86_64", "aarch64", "i386", "armv7a", "riscv64",
-	 * "riscv32", "mips64"). Determined at compile time from ARCHITECTURE_* defines.
+	 * @details Returns the OS-standard machine name for the host CPU,
+	 * detected at runtime so an emulated process (e.g. an x86 agent under
+	 * WOW64 on x64/ARM64, or an i386 agent on an x86_64 kernel) reports the
+	 * real host architecture. The OS-provided name is reported verbatim:
+	 * - Windows: IsWow64Process2 native machine (Windows 10 1511+) →
+	 *   "amd64", "arm64", "i386", "arm"; pre-1511 x86-under-WOW64 falls
+	 *   back to IsWow64Process → "amd64"
+	 * - Linux/Android: uname machine field → "x86_64", "aarch64", "armv7l", ...
+	 *   (a 32-bit personality via setarch/linux32 reports the personality
+	 *   name, e.g. "i686", not the physical CPU)
+	 * - macOS/FreeBSD: sysctl hw.machine → "arm64", "x86_64", ...
+	 *   (a Rosetta 2 process reports the emulated "x86_64")
+	 * - Solaris: sysinfo SI_ARCHITECTURE_64/32 → "amd64", "i386", ...
+	 * - iOS / UEFI / detection failure: the compile-time ARCHITECTURE_* target
+	 *   (e.g. "x86_64", "aarch64", "i386", "armv7a", "riscv64",
+	 *   "riscv32", "mips64")
 	 */
 	static USIZE GetArchitecture(Span<CHAR> buffer) noexcept;
 

--- a/src/platform/system/posix/environment.cc
+++ b/src/platform/system/posix/environment.cc
@@ -10,6 +10,11 @@
  * - GetAgentPlatform(): compile-time OS target from PLATFORM_* defines
  * - GetOSVersion(): runtime OS version via uname syscall (Linux/Android),
  *   sysctl (macOS/iOS/FreeBSD), utssys then /etc/release (Solaris), or 0 on failure
+ * - GetArchitecture(): runtime host CPU architecture via uname machine field
+ *   (Linux/Android), sysctl hw.machine (macOS/FreeBSD — iOS reports hardware
+ *   model identifiers, so it uses the compile-time fallback), or sysinfo
+ *   SI_ARCHITECTURE_64/32 (Solaris), falling back to the compile-time
+ *   ARCHITECTURE_* target
  * - GetHostname(): HOSTNAME env var (Linux/Android), /etc/hostname (Linux/Android),
  *   sysctl kern.hostname (macOS/iOS/FreeBSD), utssys then /etc/nodename (Solaris)
  *
@@ -608,8 +613,89 @@ Result<USIZE, Error> Environment::GetHostname(Span<CHAR> buffer) noexcept
 	return Result<USIZE, Error>::Err(Error(Error::None));
 }
 
+// Copy the kernel-provided machine string (uname Machine / sysctl hw.machine /
+// sysinfo SI_ARCHITECTURE) verbatim — the OS-standard name ("x86_64",
+// "armv7l", "amd64", "i686", ...) is reported unmodified. Clamps to the
+// output buffer. Returns the copied length, or 0 if empty (caller falls back
+// to the compile-time target). Unused on iOS, which skips runtime detection
+// (hw.machine reports device models there).
+[[maybe_unused]] static USIZE CopyKernelMachine(const CHAR *machine, Span<CHAR> buffer) noexcept
+{
+	if (buffer.Size() == 0)
+		return 0;
+
+	USIZE len = StringUtils::Length(machine);
+	if (len == 0)
+		return 0;
+
+	if (len >= buffer.Size())
+		len = buffer.Size() - 1;
+
+	Memory::Copy(buffer.Data(), machine, len);
+	buffer.Data()[len] = '\0';
+	return len;
+}
+
 USIZE Environment::GetArchitecture(Span<CHAR> buffer) noexcept
 {
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_ANDROID)
+	// uname reports the host machine architecture, not the build target
+	// (e.g. "x86_64" when an i386 process runs on an x86_64 kernel).
+	// Exception: a process with a 32-bit personality (setarch/linux32) or in
+	// some containers sees the personality's machine name ("i686"), not the
+	// physical CPU.
+	Utsname uts;
+	Memory::Zero(&uts, sizeof(Utsname));
+	if (System::Call(SYS_UNAME, (USIZE)&uts) == 0)
+	{
+		USIZE len = CopyKernelMachine(uts.Machine, buffer);
+		if (len > 0)
+			return len;
+	}
+#elif defined(PLATFORM_MACOS) || defined(PLATFORM_FREEBSD)
+	// sysctl hw.machine reports the host architecture ("x86_64", "arm64").
+	// iOS deliberately does not use it: on iOS devices hw.machine returns a
+	// hardware model identifier ("iPhone13,2"), not a CPU architecture, so
+	// iOS falls through to the compile-time fallback below.
+	// Note: a Rosetta 2 process on Apple Silicon reports "x86_64" here —
+	// the emulated instruction set, not the physical CPU.
+	{
+		INT32 mib[2];
+		mib[0] = 6; // CTL_HW
+		mib[1] = 1; // HW_MACHINE
+		CHAR machine[64];
+		Memory::Zero(machine, sizeof(machine));
+		USIZE len = sizeof(machine) - 1;
+		if (System::Call(SYS_SYSCTL, (USIZE)mib, 2, (USIZE)machine, (USIZE)&len, 0, 0) == 0)
+		{
+			USIZE archLen = CopyKernelMachine(machine, buffer);
+			if (archLen > 0)
+				return archLen;
+		}
+	}
+#elif defined(PLATFORM_SOLARIS)
+	// sysinfo SI_ARCHITECTURE_64 reports the kernel instruction set ("amd64",
+	// "aarch64"), so a 32-bit process on a 64-bit kernel reports the real host.
+	// On 32-bit-only kernels SI_ARCHITECTURE_64 fails with EINVAL; fall back
+	// to SI_ARCHITECTURE_32. System::Call normalizes Solaris carry-flag
+	// errors to negative returns, so >= 0 means success.
+	{
+		CHAR machine[64];
+		Memory::Zero(machine, sizeof(machine));
+		SSIZE ret = System::Call(SYS_SYSINFO, SI_ARCHITECTURE_64, (USIZE)machine, sizeof(machine) - 1);
+		if (ret < 0)
+			ret = System::Call(SYS_SYSINFO, SI_ARCHITECTURE_32, (USIZE)machine, sizeof(machine) - 1);
+		if (ret >= 0 && machine[0] != '\0')
+		{
+			machine[sizeof(machine) - 1] = '\0';
+			USIZE archLen = CopyKernelMachine(machine, buffer);
+			if (archLen > 0)
+				return archLen;
+		}
+	}
+#endif
+
+	// Fallback: the architecture the agent was compiled for.
 #if defined(ARCHITECTURE_X86_64)
 	StringUtils::Copy(buffer, Span<const CHAR>("x86_64"));
 #elif defined(ARCHITECTURE_I386)

--- a/src/platform/system/system_info.h
+++ b/src/platform/system/system_info.h
@@ -19,9 +19,11 @@
  *   Service), runtime OS version from sysctl/utssys
  * - UEFI: UUID unavailable, hostname/username unavailable (returns defaults)
  *
- * Architecture and AgentPlatform strings are determined at compile time from
- * the ARCHITECTURE_* and PLATFORM_* preprocessor defines. The OSVersion string
- * is populated at runtime via Environment::GetOSVersion().
+ * Architecture is detected at runtime via Environment::GetArchitecture() so an
+ * emulated process (e.g. x86 under WOW64) reports the real host CPU; it falls
+ * back to the compile-time ARCHITECTURE_* define when detection is unavailable.
+ * AgentPlatform is the compile-time OS target from the PLATFORM_* define. The
+ * OSVersion string is populated at runtime via Environment::GetOSVersion().
  *
  * @ingroup platform
  */
@@ -44,7 +46,7 @@ struct SystemInfo
     UUID MachineUUID;        ///< Machine-unique identifier (hardware/OS level)
     CHAR Hostname[256];      ///< Machine hostname / computer name
     CHAR Username[256];      ///< Current user name (e.g. "root", "admin"); empty if unavailable
-    CHAR Architecture[32];   ///< CPU architecture (e.g. "x86_64", "aarch64")
+    CHAR Architecture[32];   ///< Host CPU architecture (e.g. "x86_64", "aarch64"); runtime-detected, compile-time fallback
     CHAR AgentPlatform[32];  ///< Compile-time OS target (e.g. "windows", "linux")
     CHAR OSVersion[128];     ///< Runtime OS version (e.g. "Windows 10.0 Build 19045", "Linux 6.1.0")
 };
@@ -57,7 +59,8 @@ struct SystemInfo
  * - MachineUUID: Hardware/OS-level unique identifier (platform-specific)
  * - Hostname: Retrieved from OS environment (platform-specific)
  * - Username: Current user name (env, getuid()+/etc/passwd, or numeric uid)
- * - Architecture: Compile-time string from ARCHITECTURE_* define
+ * - Architecture: Runtime-detected host CPU architecture (compile-time
+ *   ARCHITECTURE_* define as fallback)
  * - AgentPlatform: Compile-time string from PLATFORM_* define
  * - OSVersion: Runtime OS version string (e.g. "Windows 10.0 Build 19045")
  *

--- a/src/platform/system/windows/environment.cc
+++ b/src/platform/system/windows/environment.cc
@@ -8,9 +8,12 @@
 
 #include "platform/system/environment.h"
 #include "platform/kernel/windows/peb.h"
+#include "platform/kernel/windows/kernel32.h"
+#include "platform/kernel/windows/ntdll.h"
 #include "core/memory/memory.h"
 #include "core/string/string.h"
 #include "platform/kernel/windows/windows_types.h"
+#include "platform/kernel/windows/pe.h"
 
 // Extended RTL_USER_PROCESS_PARAMETERS with Environment field
 // The standard definition in peb.h doesn't include all fields
@@ -201,16 +204,66 @@ Result<USIZE, Error> Environment::GetUsername(Span<CHAR> buffer) noexcept
 	return Result<USIZE, Error>::Err(Error(Error::None));
 }
 
+// Map an IMAGE_FILE_MACHINE_* code to its OS-standard architecture name, or
+// nullptr for unrecognized codes (caller falls back to the compile-time target).
+static PCCHAR MachineToName(UINT16 machine) noexcept
+{
+	switch (machine)
+	{
+		case IMAGE_FILE_MACHINE_AMD64:
+			return "amd64";
+		case IMAGE_FILE_MACHINE_I386:
+			return "i386";
+		case IMAGE_FILE_MACHINE_ARM64:
+			return "arm64";
+		case IMAGE_FILE_MACHINE_ARMNT:
+			return "arm";
+		default:
+			return nullptr;
+	}
+}
+
 USIZE Environment::GetArchitecture(Span<CHAR> buffer) noexcept
 {
+	// Query the native host architecture so an emulated process (x86 or x64
+	// under WOW64) still reports the real CPU. Machine names follow the
+	// OS-standard identifiers (amd64/arm64/i386/arm). IsWow64Process2 is only
+	// available on Windows 10 1511+; when it is missing (pre-1511), the legacy
+	// IsWow64Process (XP SP2+) can at least tell x86-under-emulation from a
+	// native x86 process: WOW64 only ever meant x64 there (the ARM64 emulator
+	// post-dates this export), so TRUE implies an amd64 host.
+	UINT16 processMachine = IMAGE_FILE_MACHINE_UNKNOWN;
+	UINT16 nativeMachine  = IMAGE_FILE_MACHINE_UNKNOWN;
+	auto wow64Result = Kernel32::IsWow64Process2(NTDLL::NtCurrentProcess(), &processMachine, &nativeMachine);
+	if (wow64Result)
+	{
+		PCCHAR name = MachineToName(nativeMachine);
+		if (name != nullptr)
+		{
+			StringUtils::Copy(buffer, Span<const CHAR>(name, StringUtils::Length(name) + 1));
+			return StringUtils::Length(buffer.Data());
+		}
+	}
+	else
+	{
+		UINT32 wow64Process = 0;
+		if (Kernel32::IsWow64Process(NTDLL::NtCurrentProcess(), &wow64Process) && wow64Process)
+		{
+			StringUtils::Copy(buffer, Span<const CHAR>("amd64"));
+			return StringUtils::Length(buffer.Data());
+		}
+	}
+
+	// Fallback: the architecture the agent was compiled for, reported with
+	// the OS-standard identifiers so it matches the runtime-detected names.
 #if defined(ARCHITECTURE_X86_64)
-	StringUtils::Copy(buffer, Span<const CHAR>("x86_64"));
+	StringUtils::Copy(buffer, Span<const CHAR>("amd64"));
 #elif defined(ARCHITECTURE_I386)
 	StringUtils::Copy(buffer, Span<const CHAR>("i386"));
 #elif defined(ARCHITECTURE_AARCH64)
-	StringUtils::Copy(buffer, Span<const CHAR>("aarch64"));
+	StringUtils::Copy(buffer, Span<const CHAR>("arm64"));
 #elif defined(ARCHITECTURE_ARMV7A)
-	StringUtils::Copy(buffer, Span<const CHAR>("armv7a"));
+	StringUtils::Copy(buffer, Span<const CHAR>("arm"));
 #else
 	buffer.Data()[0] = '\0';
 	return 0;

--- a/tests/environment_tests.h
+++ b/tests/environment_tests.h
@@ -21,7 +21,7 @@ public:
 		RunTest(allPassed, &TestGetOSVersion, "GetOSVersion returns non-empty string");
 		RunTest(allPassed, &TestGetHostname, "GetHostname returns non-empty string");
 		RunTest(allPassed, &TestGetUsername, "GetUsername returns non-empty string");
-		RunTest(allPassed, &TestGetArchitecture, "GetArchitecture returns known architecture");
+		RunTest(allPassed, &TestGetArchitecture, "GetArchitecture returns a valid machine name");
 		RunTest(allPassed, &TestGetMachineUUID, "GetMachineUUID returns valid UUID");
 		RunTest(allPassed, &TestSystemInfoPopulated, "SystemInfo fields are populated");
 
@@ -214,19 +214,25 @@ private:
 			return false;
 		}
 
-		// Must be one of the known architecture strings
-		BOOL isKnown = StringUtils::Equals(buffer, "x86_64") ||
-					   StringUtils::Equals(buffer, "i386") ||
-					   StringUtils::Equals(buffer, "aarch64") ||
-					   StringUtils::Equals(buffer, "armv7a") ||
-					   StringUtils::Equals(buffer, "riscv64") ||
-					   StringUtils::Equals(buffer, "riscv32") ||
-					   StringUtils::Equals(buffer, "mips64") ||
-					   StringUtils::Equals(buffer, "mips");
-
-		if (!isKnown)
+		// The OS-provided machine name is reported verbatim (e.g. "x86_64",
+		// "arm64", "amd64", "armv7l", "i686"). Assert it is a machine name,
+		// not an arbitrary string: lowercase letters, digits, and underscores
+		// only. This rejects hardware model identifiers ("iPhone13,2"),
+		// hostnames, and truncated/garbage output while still accepting every
+		// legitimate kernel-provided machine string.
+		for (USIZE i = 0; i < len; i++)
 		{
-			LOG_ERROR("GetArchitecture returned unknown value: %s", buffer);
+			CHAR c = buffer[i];
+			BOOL valid = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
+			if (!valid)
+			{
+				LOG_ERROR("GetArchitecture returned invalid character '%c' (0x%x) at %llu", c, (UINT32)c, (UINT64)i);
+				return false;
+			}
+		}
+		if (buffer[len] != '\0')
+		{
+			LOG_ERROR("GetArchitecture result is not null-terminated at len");
 			return false;
 		}
 


### PR DESCRIPTION
## Summary

`SystemInfo.Architecture` now detects the real host CPU architecture at runtime from the OS (Windows: `IsWow64Process2` with `IsWow64Process` fallback pre-Win10 1511; Linux/Android: `uname` machine field; macOS/FreeBSD: `sysctl hw.machine`; Solaris: `sysinfo SI_ARCHITECTURE_64/32`), reporting the OS-provided name verbatim with the compile-time `ARCHITECTURE_*` string as fallback — so an x86/x64 agent under WOW64 or an i386 agent on an x86_64 kernel reports the actual host. Also fixes export resolution for API-set forwarded exports (`kernel32 → api-ms-win-core-*`), which previously resolved `IsWow64Process2` to null on WOW64.

## Type of Change

- [x] Bug fix
- [x] New feature / command
- [ ] Refactoring (no functional changes)
- [x] Documentation
- [ ] Build system / CI
- [ ] Other:

## Platforms Tested

- [x] `windows-x86_64-release`
- [ ] `linux-x86_64-release`
- [ ] `macos-aarch64-release`
- [x] Other: `linux-x86_64-debug` (BUILD_TESTS — full suite executed, ALL TESTS PASSED, `Architecture: x86_64` detected via uname); compile-only with 0 warnings + PIC passed: `windows-i386-release`, `windows-aarch64-release`, `solaris-x86_64-release`, `solaris-i386-release`, `freebsd-x86_64-release`, `macos-aarch64-release`, `android-aarch64-release`

## Binary Size Impact

```
Preset: windows-x86_64-release
Before: exe 103038, bin 100.6 KiB
After:  exe 103762, bin 101.3 KiB
Diff:   +724 B
```

## Checklist

- [x] Build passes with no warnings for at least one preset
- [x] Post-build PIC verification passes (no `.rdata`/`.rodata`/`.data`/`.bss` sections)
- [x] Code follows [naming conventions](CONTRIBUTING.md#naming-conventions) and [code style](CONTRIBUTING.md#code-style)
- [x] Doxygen documentation added for new public APIs
- [x] No STL, no exceptions, no RTTI
- [x] `Result<T, Error>` used for all fallible functions
- [x] Binary size diff reported above
- [x] README updated (if adding/modifying commands)

## Additional Notes

**API-set forwarder fix:** `kernel32!IsWow64Process2` is a forwarded export to `api-ms-win-core-wow64-l1-1-1` — an API-set schema name, not a real DLL. The PEB module lookup found no module with that name and returned null (confirmed by parsing SysWOW64/System32 export tables on a real machine). The resolver now falls back to `LdrLoadDll`, which understands API-set names natively and maps them onto the host DLL (kernelbase.dll, where the real code lives).

**Verbatim naming:** the OS string is reported unmodified by design, so the same hardware can legitimately report different strings per OS (FreeBSD `amd64` vs Linux `x86_64`; Windows `arm64` vs Linux `aarch64`).

**Known limits:** Rosetta 2 on macOS reports the emulated `x86_64`; full-system emulation (QEMU/VM) is undetectable from inside the guest; a Linux process with a 32-bit personality (`setarch`/`linux32`) reports the personality's machine name; iOS reports the compile-time target because `hw.machine` returns device models (`iPhone13,2`), not architectures.

**Solaris note:** syscall failures return a positive errno with the carry flag set (not `-errno` like Linux), so the `sysinfo` result is validated by buffer content rather than return code.
